### PR TITLE
Bug/range not updated

### DIFF
--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -41,13 +41,14 @@ class DateRange extends Component {
     }
   }
 
-  setRange(range) {
+  setRange(range, {silent = false}={}) {
     const { onChange } = this.props;
     range = this.orderRange(range);
 
     this.setState({ range });
 
-    onChange && onChange(range);
+    if (!silent)
+      onChange && onChange(range);
   }
 
   handleSelect(date) {
@@ -99,7 +100,7 @@ class DateRange extends Component {
       this.setRange({
         startDate: startDate,
         endDate: endDate
-      });
+      }, {silent: true});
     }
   }
 

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -89,6 +89,21 @@ class DateRange extends Component {
     });
   }
 
+  componentWillReceiveProps(newProps) {
+    // Whenever date props changes, update state with parsed variant
+    if (newProps.startDate || newProps.endDate) {
+      const startDate = newProps.startDate ? parseInput(newProps.startDate, format) : this.props.startDate;
+      const endDate   = newProps.endDate ? parseInput(newProps.endDate, format) : this.props.endDate;
+
+      this.setState({
+        range: {
+          startDate: startDate,
+          endDate: endDate
+        }
+      });
+    }
+  }
+
   render() {
     const { ranges, format, linkedCalendars, style, calendars } = this.props;
     const { range, link } = this.state;

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -18,7 +18,7 @@ class DateRange extends Component {
     this.state = {
       range     : { startDate, endDate },
       link      : linkedCalendars && endDate,
-    }
+    };
 
     this.step = 0;
     this.styles = getTheme(theme);
@@ -42,7 +42,7 @@ class DateRange extends Component {
   }
 
   setRange(range) {
-    const { onChange } = this.props
+    const { onChange } = this.props;
     range = this.orderRange(range);
 
     this.setState({ range });
@@ -96,11 +96,9 @@ class DateRange extends Component {
       const startDate = newProps.startDate ? parseInput(newProps.startDate, format) : this.props.startDate;
       const endDate   = newProps.endDate ? parseInput(newProps.endDate, format) : this.props.endDate;
 
-      this.setState({
-        range: {
-          startDate: startDate,
-          endDate: endDate
-        }
+      this.setRange({
+        startDate: startDate,
+        endDate: endDate
       });
     }
   }
@@ -147,7 +145,7 @@ DateRange.defaultProps = {
   theme           : {},
   format          : 'DD/MM/YYYY',
   calendars       : 2
-}
+};
 
 DateRange.propTypes = {
   format    : PropTypes.string,
@@ -162,6 +160,6 @@ DateRange.propTypes = {
   theme     : PropTypes.object,
   onInit    : PropTypes.func,
   onChange  : PropTypes.func,
-}
+};
 
 export default DateRange;

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -92,6 +92,7 @@ class DateRange extends Component {
   componentWillReceiveProps(newProps) {
     // Whenever date props changes, update state with parsed variant
     if (newProps.startDate || newProps.endDate) {
+      const format    = newProps.format || this.props.format;
       const startDate = newProps.startDate ? parseInput(newProps.startDate, format) : this.props.startDate;
       const endDate   = newProps.endDate ? parseInput(newProps.endDate, format) : this.props.endDate;
 


### PR DESCRIPTION
This fixes #5.

This pull request listens for prop changes, and whenever any of those two properties change, we re-parse them.

Note/discussion:
this might be a problem for other properties as well, but I only solved it for my use case for now.
Ideally, we would perhaps restructure the code so that the dates information is not stored in two places (props and state). One could for instance store the dates only as props, and do the parsing of the dates only when needed (i.e. in render)