### PR TITLE
Support newer version of React by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "moment": "^2.10.6",
-    "react": ">0.13.0 <0.14.1"
+    "react": ">=0.13.0"
   },
   "devDependencies": {
     "babel": "^5.8.23"


### PR DESCRIPTION
This will allow users to use this repo with newest version of React.
Tested in 0.14.2 and everything looks great.