### PR TITLE
Add theming utilities.

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -6,6 +6,12 @@ Object.defineProperty(exports, '__esModule', {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
+
+var _utilsTheming = require('./utils/theming');
+
+var themingUtils = _interopRequireWildcard(_utilsTheming);
+
 var defaultTheme = {
   DateRange: {
     display: 'block',
@@ -136,9 +142,8 @@ var defaultTheme = {
 exports['default'] = function () {
   var customTheme = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
 
-  var calendarWidth = customTheme.Calendar && customTheme.Calendar.width || defaultTheme.Calendar && defaultTheme.Calendar.width;
-
-  var calendarPaddding = customTheme.Calendar && customTheme.Calendar.padding || defaultTheme.Calendar && defaultTheme.Calendar.padding;
+  var calendarWidth = themingUtils.getStyleValue(customTheme.Calendar, defaultTheme.Calendar, 'width', 'number');
+  var calendarPaddding = themingUtils.getStyleValue(customTheme.Calendar, defaultTheme.Calendar, 'padding', 'number');
 
   var cellSize = (calendarWidth - calendarPaddding * 2) / 7;
 

--- a/lib/utils/theming.js
+++ b/lib/utils/theming.js
@@ -1,0 +1,23 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports.getStyleValue = getStyleValue;
+var isExpectedType = function isExpectedType(obj, type) {
+	return typeof obj === type;
+};
+
+function getStyleValue(customTheme, defaultTheme, style, type) {
+	var defaultValue = arguments.length <= 4 || arguments[4] === undefined ? 0 : arguments[4];
+
+	if (!isExpectedType(customTheme[style], "undefined") && isExpectedType(customTheme[style], type)) {
+		return customTheme[style];
+	} else if (!isExpectedType(defaultTheme[style], "undefined")) {
+		return defaultTheme[style];
+	} else {
+		return defaultValue;
+	}
+}
+
+;

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,3 +1,5 @@
+import * as themingUtils from './utils/theming'
+
 const defaultTheme = {
   DateRange : {
     display       : 'block',
@@ -127,11 +129,8 @@ const defaultTheme = {
 
 export default (customTheme = {}) => {
 
-  const calendarWidth = (customTheme.Calendar && customTheme.Calendar.width) ||
-                        (defaultTheme.Calendar && defaultTheme.Calendar.width);
-
-  const calendarPaddding = (customTheme.Calendar && customTheme.Calendar.padding) ||
-                           (defaultTheme.Calendar && defaultTheme.Calendar.padding);
+  const calendarWidth = themingUtils.getStyleValue(customTheme.Calendar, defaultTheme.Calendar, 'width', 'number');
+  const calendarPaddding = themingUtils.getStyleValue(customTheme.Calendar, defaultTheme.Calendar, 'padding', 'number');
 
   const cellSize = ( calendarWidth - calendarPaddding * 2 ) / 7;
 

--- a/src/utils/theming.js
+++ b/src/utils/theming.js
@@ -1,0 +1,14 @@
+let isExpectedType = (obj, type) => typeof obj === type;
+
+export function getStyleValue(customTheme, defaultTheme, style, type, defaultValue = 0) {
+	
+	if (!isExpectedType(customTheme[style], "undefined") && isExpectedType(customTheme[style], type)) {
+		return customTheme[style];
+	}
+	else if (!isExpectedType(defaultTheme[style], "undefined")) {
+		return defaultTheme[style];
+	}
+	else {
+		return defaultValue;
+	}
+};


### PR DESCRIPTION
I originally wanted to do a simple PR to fix a bug wich occures when we set `padding` to `0` in `Calendar` theme as this is currently not possible because of the way you check the existence of a custom value.

Then, I ended up with a totally different proposal :D : new utilities in `theming.js`

```javascript
/**
 *
 * @param {Object} customTheme
 * @param {Object} defaultTheme
 * @param {String} style
 * @param {String} type
 * @param {*} defaultValue
 * @returns {*}
 */
export function getStyleValue(customTheme, defaultTheme, style, type, defaultValue = 0) {};

// usage :
let calendarPadding = themingUtils.getStyleValue(customTheme.Calendar, defaultTheme.Calendar, 'padding', 'number', 0);

// means: here are two themes objects, give me the first value of `width` key which returns truthy for 
// my `type`. Else, here is a `defaultValue`.
```

Feedback much appreciated :)