### PR TITLE
Configurable Classes

### DIFF
--- a/demo/build.js
+++ b/demo/build.js
@@ -13,8 +13,7 @@ var config = {
 
   output                : {
     path                : path.join(__dirname, '/dist'),
-    filename            : '[name].js',
-    publicPath          : '/'
+    filename            : '[name].js'
   },
 
   devtool               : ((NODE_ENV==='development') ? 'source-map' : false),

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { defaultRanges, Calendar, DateRange } from 'react-date-range';
+import { defaultRanges, Calendar, DateRange } from '../../../lib/';
 import Section from 'components/Section';
 
 import 'normalize.css';

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -124,20 +124,21 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderMonthAndYear',
-    value: function renderMonthAndYear() {
+    value: function renderMonthAndYear(classes) {
       var shownDate = this.getShownDate();
       var month = _moment2['default'].months(shownDate.month());
       var year = shownDate.year();
       var styles = this.styles;
+      var onlyClasses = this.props.onlyClasses;
 
       return _react2['default'].createElement(
         'div',
-        { style: styles['MonthAndYear'], className: 'rdr-MonthAndYear-innerWrapper' },
+        { style: !onlyClasses && styles['MonthAndYear'], className: classes.monthAndYearWrapper },
         _react2['default'].createElement(
           'button',
           {
-            style: _extends({}, styles['MonthButton'], { float: 'left' }),
-            className: 'rdr-MonthAndYear-button prev',
+            style: !onlyClasses && _extends({}, styles['MonthButton'], { float: 'left' }),
+            className: classes.prevButton,
             onClick: this.changeMonth.bind(this, -1, false) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowPrev']) })
         ),
@@ -146,25 +147,25 @@ var Calendar = (function (_Component) {
           null,
           _react2['default'].createElement(
             'span',
-            { className: 'rdr-MonthAndYear-month' },
+            { className: classes.month },
             month
           ),
           _react2['default'].createElement(
             'span',
-            { className: 'rdr-MonthAndYear-divider' },
+            { className: classes.monthAndYearDivider },
             ' - '
           ),
           _react2['default'].createElement(
             'span',
-            { className: 'rdr-MonthAndYear-year' },
+            { className: classes.year },
             year
           )
         ),
         _react2['default'].createElement(
           'button',
           {
-            style: _extends({}, styles['MonthButton'], { float: 'right' }),
-            className: 'rdr-MonthAndYear-button next',
+            style: !onlyClasses && _extends({}, styles['MonthButton'], { float: 'right' }),
+            className: classes.nextButton,
             onClick: this.changeMonth.bind(this, +1, false) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowNext']) })
         )
@@ -172,17 +173,18 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderWeekdays',
-    value: function renderWeekdays() {
+    value: function renderWeekdays(classes) {
       var dow = this.state.firstDayOfWeek;
       var weekdays = [];
       var styles = this.styles;
+      var onlyClasses = this.props.onlyClasses;
 
       for (var i = dow; i < 7 + dow; i++) {
         var day = _moment2['default'].weekdaysMin(i);
 
         weekdays.push(_react2['default'].createElement(
           'span',
-          { style: styles['Weekday'], className: 'rdr-WeekDay', key: day },
+          { style: !onlyClasses && styles['Weekday'], className: classes.weekDay, key: day },
           day
         ));
       }
@@ -191,12 +193,14 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderDays',
-    value: function renderDays() {
+    value: function renderDays(classes) {
       var _this = this;
 
       // TODO: Split this logic into smaller chunks
       var styles = this.styles;
-      var range = this.props.range;
+      var _props4 = this.props;
+      var range = _props4.range;
+      var onlyClasses = _props4.onlyClasses;
 
       var shownDate = this.getShownDate();
       var _state = this.state;
@@ -252,7 +256,9 @@ var Calendar = (function (_Component) {
           theme: styles,
           isSelected: isSelected || isEdge,
           isInRange: isInRange,
-          key: index
+          key: index,
+          onlyClasses: onlyClasses,
+          classNames: classes
         }));
       });
     }
@@ -260,24 +266,28 @@ var Calendar = (function (_Component) {
     key: 'render',
     value: function render() {
       var styles = this.styles;
+      var classNames = this.classNames;
+      var onlyClasses = this.props.onlyClasses;
+
+      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
 
       return _react2['default'].createElement(
         'div',
-        { style: _extends({}, styles['Calendar'], this.props.style), className: 'rdr-Calendar' },
+        { style: !onlyClasses && _extends({}, styles['Calendar'], this.props.style), className: classes.calendar },
         _react2['default'].createElement(
           'div',
-          { className: 'rdr-MonthAndYear' },
-          this.renderMonthAndYear()
+          { className: classes.monthAndYear },
+          this.renderMonthAndYear(classes)
         ),
         _react2['default'].createElement(
           'div',
-          { className: 'rdr-WeekDays' },
-          this.renderWeekdays()
+          { className: classes.weekDays },
+          this.renderWeekdays(classes)
         ),
         _react2['default'].createElement(
           'div',
-          { className: 'rdr-Days' },
-          this.renderDays()
+          { className: classes.days },
+          this.renderDays(classes)
         )
       );
     }
@@ -288,7 +298,9 @@ var Calendar = (function (_Component) {
 
 Calendar.defaultProps = {
   format: 'DD/MM/YYYY',
-  theme: {}
+  theme: {},
+  onlyClasses: false,
+  classNames: {}
 };
 
 Calendar.propTypes = {
@@ -307,7 +319,9 @@ Calendar.propTypes = {
     endDate: _react.PropTypes.object
   }), _react.PropTypes.bool]),
   linkCB: _react.PropTypes.func,
-  theme: _react.PropTypes.object
+  theme: _react.PropTypes.object,
+  onlyClasses: _react.PropTypes.bool,
+  classNames: _react.PropTypes.object
 };
 
 exports['default'] = Calendar;

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -171,19 +171,25 @@ var DateRange = (function (_Component) {
       var style = _props.style;
       var calendars = _props.calendars;
       var firstDayOfWeek = _props.firstDayOfWeek;
+      var classNames = _props.classNames;
+      var onlyClasses = _props.onlyClasses;
       var _state = this.state;
       var range = _state.range;
       var link = _state.link;
       var styles = this.styles;
 
+      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
+
       return _react2['default'].createElement(
         'div',
-        { style: _extends({}, styles['DateRange'], style), className: 'rdr-DateRange' },
+        { style: !onlyClasses && _extends({}, styles['DateRange'], style), className: classes.dateRange },
         ranges && _react2['default'].createElement(_PredefinedRangesJs2['default'], {
           format: format,
           ranges: ranges,
           theme: styles,
-          onSelect: this.handleSelect.bind(this) }),
+          onSelect: this.handleSelect.bind(this),
+          onlyClasses: onlyClasses,
+          classNames: classes }),
         (function () {
           var _calendars = [];
           for (var i = Number(calendars) - 1; i >= 0; i--) {
@@ -196,7 +202,9 @@ var DateRange = (function (_Component) {
               format: format,
               firstDayOfWeek: firstDayOfWeek,
               theme: styles,
-              onChange: _this.handleSelect.bind(_this) }));
+              onChange: _this.handleSelect.bind(_this),
+              onlyClasses: onlyClasses,
+              classNames: classes }));
           }
           return _calendars;
         })()
@@ -211,7 +219,9 @@ DateRange.defaultProps = {
   linkedCalendars: false,
   theme: {},
   format: 'DD/MM/YYYY',
-  calendars: 2
+  calendars: 2,
+  onlyClasses: false,
+  classNames: {}
 };
 
 DateRange.propTypes = {
@@ -227,7 +237,9 @@ DateRange.propTypes = {
   linkedCalendars: _react.PropTypes.bool,
   theme: _react.PropTypes.object,
   onInit: _react.PropTypes.func,
-  onChange: _react.PropTypes.func
+  onChange: _react.PropTypes.func,
+  onlyClasses: _react.PropTypes.bool,
+  classNames: _react.PropTypes.object
 };
 
 exports['default'] = DateRange;

--- a/lib/DayCell.js
+++ b/lib/DayCell.js
@@ -12,6 +12,8 @@ var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_ag
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -19,6 +21,12 @@ function _inherits(subClass, superClass) { if (typeof superClass !== 'function' 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _classnames2 = require('classnames');
+
+var _classnames3 = _interopRequireDefault(_classnames2);
+
+var _stylesJs = require('./styles.js');
 
 var DayCell = (function (_Component) {
   _inherits(DayCell, _Component);
@@ -94,28 +102,27 @@ var DayCell = (function (_Component) {
     }
   }, {
     key: 'getClassNames',
-    value: function getClassNames() {
+    value: function getClassNames(classes) {
+      var _classnames;
+
       var _props2 = this.props;
       var isSelected = _props2.isSelected;
       var isInRange = _props2.isInRange;
       var isPassive = _props2.isPassive;
 
-      var classNames = 'rdr-Day ';
-
-      classNames = isSelected ? classNames + 'is-selected ' : classNames;
-      classNames = isInRange ? classNames + 'is-inRange ' : classNames;
-      classNames = isPassive ? classNames + 'is-passive ' : classNames;
-
-      return classNames;
+      return (0, _classnames3['default'])((_classnames = {}, _defineProperty(_classnames, classes.day, true), _defineProperty(_classnames, classes.dayActive, isSelected), _defineProperty(_classnames, classes.dayPassive, isPassive), _defineProperty(_classnames, classes.dayInRange, isInRange), _classnames));
     }
   }, {
     key: 'render',
     value: function render() {
+      var _props3 = this.props;
+      var dayMoment = _props3.dayMoment;
+      var onlyClasses = _props3.onlyClasses;
+      var classNames = _props3.classNames;
       var styles = this.styles;
-      var dayMoment = this.props.dayMoment;
 
       var stateStyle = this.getStateStyles();
-      var classNames = this.getClassNames();
+      var classes = this.getClassNames(classNames);
 
       return _react2['default'].createElement(
         'span',
@@ -125,8 +132,8 @@ var DayCell = (function (_Component) {
           onMouseDown: this.handleMouseEvent.bind(this),
           onMouseUp: this.handleMouseEvent.bind(this),
           onClick: this.handleSelect.bind(this),
-          className: classNames,
-          style: _extends({}, styles['Day'], stateStyle) },
+          className: classes,
+          style: !onlyClasses && _extends({}, styles['Day'], stateStyle) },
         dayMoment.date()
       );
     }
@@ -136,7 +143,8 @@ var DayCell = (function (_Component) {
 })(_react.Component);
 
 DayCell.defaultProps = {
-  theme: { 'Day': {} }
+  theme: { 'Day': {} },
+  onlyClasses: false
 };
 
 DayCell.propTypes = {
@@ -147,7 +155,9 @@ DayCell.propTypes = {
   isPassive: _react.PropTypes.bool,
   theme: _react.PropTypes.shape({
     Day: _react.PropTypes.object.isRequired
-  }).isRequired
+  }).isRequired,
+  onlyClasses: _react.PropTypes.bool,
+  classNames: _react.PropTypes.object
 };
 
 exports['default'] = DayCell;

--- a/lib/PredefinedRanges.js
+++ b/lib/PredefinedRanges.js
@@ -20,13 +20,15 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _moment = require('moment');
+
+var _moment2 = _interopRequireDefault(_moment);
+
 var _utilsParseInputJs = require('./utils/parseInput.js');
 
 var _utilsParseInputJs2 = _interopRequireDefault(_utilsParseInputJs);
 
-var _moment = require('moment');
-
-var _moment2 = _interopRequireDefault(_moment);
+var _stylesJs = require('./styles.js');
 
 var PredefinedRanges = (function (_Component) {
   _inherits(PredefinedRanges, _Component);
@@ -54,7 +56,7 @@ var PredefinedRanges = (function (_Component) {
     }
   }, {
     key: 'renderRangeList',
-    value: function renderRangeList() {
+    value: function renderRangeList(classes) {
       var _this = this;
 
       var ranges = this.props.ranges;
@@ -66,7 +68,7 @@ var PredefinedRanges = (function (_Component) {
           {
             href: '#',
             key: 'range-' + name,
-            className: 'rdr-PredefinedRangeItem',
+            className: classes.predefinedRangeItem,
             style: styles['PredefinedRangeItem'],
             onClick: _this.handleSelect.bind(_this, name) },
           name
@@ -76,13 +78,18 @@ var PredefinedRanges = (function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var style = this.props.style;
+      var _props = this.props;
+      var style = _props.style;
+      var onlyClasses = _props.onlyClasses;
+      var classNames = _props.classNames;
       var styles = this.styles;
+
+      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
 
       return _react2['default'].createElement(
         'div',
-        { style: _extends({}, styles['PredefinedRanges'], style), className: 'rdr-PredefinedRanges' },
-        this.renderRangeList()
+        { style: !onlyClasses && _extends({}, styles['PredefinedRanges'], style), className: classes.predefinedRanges },
+        this.renderRangeList(classes)
       );
     }
   }]);
@@ -90,8 +97,15 @@ var PredefinedRanges = (function (_Component) {
   return PredefinedRanges;
 })(_react.Component);
 
+PredefinedRanges.defaultProps = {
+  onlyClasses: false,
+  classNames: {}
+};
+
 PredefinedRanges.propTypes = {
-  ranges: _react.PropTypes.object.isRequired
+  ranges: _react.PropTypes.object.isRequired,
+  onlyClasses: _react.PropTypes.bool,
+  classNames: _react.PropTypes.object
 };
 
 exports['default'] = PredefinedRanges;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -6,6 +6,28 @@ Object.defineProperty(exports, '__esModule', {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var defaultClasses = {
+  calendar: 'rdr-Calendar',
+  dateRange: 'rdr-DateRange',
+  predefinedRanges: 'rdr-PredefinedRanges',
+  predefinedRangesItem: 'rdr-PredefinedRangeItem',
+  monthAndYear: 'rdr-MonthAndYear',
+  weekDays: 'rdr-WeekDays',
+  weekDay: 'rdr-WeekDay',
+  days: 'rdr-Days',
+  day: 'rdr-Day',
+  dayActive: 'is-selected',
+  dayPassive: 'is-passive',
+  dayInRange: 'is-inRange',
+  monthAndYearWrapper: 'rdr-MonthAndYear-innerWrapper',
+  prevButton: 'rdr-MonthAndYear-button prev',
+  nextButton: 'rdr-MonthAndYear-button next',
+  month: 'rdr-MonthAndYear-month',
+  monthAndYearDivider: 'rdr-MonthAndYear-divider',
+  year: 'rdr-MonthAndYear-year'
+};
+
+exports.defaultClasses = defaultClasses;
 var defaultTheme = {
   DateRange: {
     display: 'block',
@@ -191,5 +213,3 @@ exports['default'] = function () {
     PredefinedRangeItem: _extends({}, defaultTheme.PredefinedRangeItem, customTheme.PredefinedRangeItem)
   };
 };
-
-module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "http://github.com/Adphorus/react-date-range/issues"
   },
   "dependencies": {
+    "classnames": "^2.2.1",
     "moment": "^2.10.6",
     "react": ">=0.13.0"
   },

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 import parseInput from './utils/parseInput.js';
 import DayCell from './DayCell.js';
-import getTheme from './styles.js';
+import getTheme, { defaultClasses } from './styles.js';
 
 function checkRange(dayMoment, range) {
   return (
@@ -77,28 +77,29 @@ class Calendar extends Component {
     });
   }
 
-  renderMonthAndYear() {
-    const shownDate  = this.getShownDate();
-    const month      = moment.months(shownDate.month());
-    const year       = shownDate.year();
-    const { styles } = this;
+  renderMonthAndYear(classes) {
+    const shownDate       = this.getShownDate();
+    const month           = moment.months(shownDate.month());
+    const year            = shownDate.year();
+    const { styles }      = this;
+    const { onlyClasses } = this.props;
 
     return (
-      <div style={styles['MonthAndYear']} className='rdr-MonthAndYear-innerWrapper'>
+      <div style={!onlyClasses && styles['MonthAndYear']} className={classes.monthAndYearWrapper}>
         <button
-          style={{ ...styles['MonthButton'], float : 'left' }}
-          className='rdr-MonthAndYear-button prev'
+          style={!onlyClasses && { ...styles['MonthButton'], float : 'left' }}
+          className={classes.prevButton}
           onClick={this.changeMonth.bind(this, -1, false)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowPrev'] }}></i>
         </button>
         <span>
-          <span className='rdr-MonthAndYear-month'>{month}</span>
-          <span className='rdr-MonthAndYear-divider'> - </span>
-          <span className='rdr-MonthAndYear-year'>{year}</span>
+          <span className={classes.month}>{month}</span>
+          <span className={classes.monthAndYearDivider}> - </span>
+          <span className={classes.year}>{year}</span>
         </span>
         <button
-          style={{ ...styles['MonthButton'], float : 'right' }}
-          className='rdr-MonthAndYear-button next'
+          style={!onlyClasses && { ...styles['MonthButton'], float : 'right' }}
+          className={classes.nextButton}
           onClick={this.changeMonth.bind(this, +1, false)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowNext'] }}></i>
         </button>
@@ -106,27 +107,28 @@ class Calendar extends Component {
     )
   }
 
-  renderWeekdays() {
-    const dow        = this.state.firstDayOfWeek;
-    const weekdays   = [];
-    const { styles } = this;
+  renderWeekdays(classes) {
+    const dow             = this.state.firstDayOfWeek;
+    const weekdays        = [];
+    const { styles }      = this;
+    const { onlyClasses } = this.props;
 
     for (let i = dow; i < 7 + dow; i++) {
       const day = moment.weekdaysMin(i);
 
       weekdays.push(
-        <span style={styles['Weekday']} className='rdr-WeekDay' key={day}>{day}</span>
+        <span style={!onlyClasses && styles['Weekday']} className={classes.weekDay} key={day}>{day}</span>
       );
     }
 
     return weekdays;
   }
 
-  renderDays() {
+  renderDays(classes) {
     // TODO: Split this logic into smaller chunks
     const { styles }               = this;
 
-    const { range }                = this.props;
+    const { range, onlyClasses }   = this.props;
 
     const shownDate                = this.getShownDate();
     const { date, firstDayOfWeek } = this.state;
@@ -179,27 +181,34 @@ class Calendar extends Component {
           isSelected={ isSelected || isEdge }
           isInRange={ isInRange }
           key={ index }
+          onlyClasses = { onlyClasses }
+          classNames = { classes }
         />
       );
     })
   }
 
   render() {
-    const { styles } = this;
+    const { styles, classNames } = this;
+    const { onlyClasses }        = this.props;
+
+    const classes = { ...defaultClasses, ...classNames };
 
     return (
-      <div style={{ ...styles['Calendar'], ...this.props.style }} className='rdr-Calendar'>
-        <div className='rdr-MonthAndYear'>{ this.renderMonthAndYear() }</div>
-        <div className='rdr-WeekDays'>{ this.renderWeekdays() }</div>
-        <div className='rdr-Days'>{ this.renderDays() }</div>
+      <div style={ !onlyClasses && { ...styles['Calendar'], ...this.props.style }} className={classes.calendar}>
+        <div className={classes.monthAndYear}>{ this.renderMonthAndYear(classes) }</div>
+        <div className={classes.weekDays}>{ this.renderWeekdays(classes) }</div>
+        <div className={classes.days}>{ this.renderDays(classes) }</div>
       </div>
     )
   }
 }
 
 Calendar.defaultProps = {
-  format    : 'DD/MM/YYYY',
-  theme     : {},
+  format      : 'DD/MM/YYYY',
+  theme       : {},
+  onlyClasses : false,
+  classNames  : {}
 }
 
 Calendar.propTypes = {
@@ -219,6 +228,8 @@ Calendar.propTypes = {
   }), PropTypes.bool]),
   linkCB         : PropTypes.func,
   theme          : PropTypes.object,
+  onlyClasses    : PropTypes.bool,
+  classNames     : PropTypes.object
 }
 
 export default Calendar;

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import parseInput from './utils/parseInput.js';
 import Calendar from './Calendar.js';
 import PredefinedRanges from './PredefinedRanges.js';
-import getTheme from './styles.js';
+import getTheme, { defaultClasses } from './styles.js';
 
 class DateRange extends Component {
 
@@ -108,18 +108,22 @@ class DateRange extends Component {
   }
 
   render() {
-    const { ranges, format, linkedCalendars, style, calendars, firstDayOfWeek } = this.props;
+    const { ranges, format, linkedCalendars, style, calendars, firstDayOfWeek, classNames, onlyClasses } = this.props;
     const { range, link } = this.state;
     const { styles } = this;
 
+    const classes = { ...defaultClasses, ...classNames };
+
     return (
-      <div style={{ ...styles['DateRange'], ...style }} className='rdr-DateRange'>
+      <div style={!onlyClasses && { ...styles['DateRange'], ...style }} className={classes.dateRange}>
         { ranges && (
           <PredefinedRanges
             format={ format }
             ranges={ ranges }
             theme={ styles }
-            onSelect={this.handleSelect.bind(this)} />
+            onSelect={this.handleSelect.bind(this)}
+            onlyClasses={ onlyClasses }
+            classNames={ classes } />
         )}
 
         {()=>{
@@ -135,7 +139,9 @@ class DateRange extends Component {
                 format={ format }
                 firstDayOfWeek={ firstDayOfWeek }
                 theme={ styles }
-                onChange={ this.handleSelect.bind(this) }  />
+                onChange={ this.handleSelect.bind(this) }
+                onlyClasses={ onlyClasses }
+                classNames={ classes }  />
             );
           }
           return _calendars;
@@ -149,7 +155,9 @@ DateRange.defaultProps = {
   linkedCalendars : false,
   theme           : {},
   format          : 'DD/MM/YYYY',
-  calendars       : 2
+  calendars       : 2,
+  onlyClasses     : false,
+  classNames      : {}
 }
 
 DateRange.propTypes = {
@@ -166,6 +174,8 @@ DateRange.propTypes = {
   theme           : PropTypes.object,
   onInit          : PropTypes.func,
   onChange        : PropTypes.func,
+  onlyClasses     : PropTypes.bool,
+  classNames      : PropTypes.object
 }
 
 export default DateRange;

--- a/src/DayCell.js
+++ b/src/DayCell.js
@@ -1,4 +1,7 @@
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+
+import { defaultClasses } from './styles.js';
 
 class DayCell extends Component {
 
@@ -67,23 +70,24 @@ class DayCell extends Component {
     };
   }
 
-  getClassNames() {
+  getClassNames(classes) {
     const { isSelected, isInRange, isPassive } = this.props;
 
-    let classNames = 'rdr-Day ';
+    return classnames({
+      [classes.day]       : true,
+      [classes.dayActive] : isSelected,
+      [classes.dayPassive]: isPassive,
+      [classes.dayInRange]: isInRange
+    });
 
-    classNames = (isSelected) ? classNames + 'is-selected ' : classNames;
-    classNames = (isInRange) ? classNames + 'is-inRange ' : classNames;
-    classNames = (isPassive) ? classNames + 'is-passive ' : classNames;
-
-    return classNames;
   }
 
   render() {
-    const { styles }    = this;
-    const { dayMoment } = this.props;
-    const stateStyle    = this.getStateStyles();
-    const classNames    = this.getClassNames();
+    const { dayMoment, onlyClasses, classNames } = this.props;
+
+    const { styles } = this;
+    const stateStyle = this.getStateStyles();
+    const classes    = this.getClassNames(classNames);
 
     return (
       <span
@@ -92,8 +96,8 @@ class DayCell extends Component {
         onMouseDown={ this.handleMouseEvent.bind(this) }
         onMouseUp={ this.handleMouseEvent.bind(this) }
         onClick={ this.handleSelect.bind(this) }
-        className={ classNames }
-        style={{...styles['Day'], ...stateStyle}}>
+        className={ classes }
+        style={!onlyClasses && {...styles['Day'], ...stateStyle}}>
         { dayMoment.date() }
       </span>
     );
@@ -101,18 +105,21 @@ class DayCell extends Component {
 }
 
 DayCell.defaultProps = {
-  theme      : { 'Day' : {} }
+  theme       : { 'Day' : {} },
+  onlyClasses : false
 }
 
 DayCell.propTypes = {
-  dayMoment  : PropTypes.object.isRequired,
-  onSelect   : PropTypes.func,
-  isSelected : PropTypes.bool,
-  isInRange  : PropTypes.bool,
-  isPassive  : PropTypes.bool,
-  theme      : PropTypes.shape({
-    Day      : PropTypes.object.isRequired
+  dayMoment   : PropTypes.object.isRequired,
+  onSelect    : PropTypes.func,
+  isSelected  : PropTypes.bool,
+  isInRange   : PropTypes.bool,
+  isPassive   : PropTypes.bool,
+  theme       : PropTypes.shape({
+    Day       : PropTypes.object.isRequired
   }).isRequired,
+  onlyClasses : PropTypes.bool,
+  classNames  : PropTypes.object
 }
 
 export default DayCell;

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
-import parseInput from './utils/parseInput.js';
 import moment from 'moment';
+
+import parseInput from './utils/parseInput.js';
+import { defaultStyle } from './styles.js';
 
 class PredefinedRanges extends Component {
 
@@ -22,7 +24,7 @@ class PredefinedRanges extends Component {
     });
   }
 
-  renderRangeList() {
+  renderRangeList(classes) {
     const { ranges } = this.props;
     const { styles } = this;
 
@@ -31,7 +33,7 @@ class PredefinedRanges extends Component {
         <a
           href='#'
           key={'range-' + name}
-          className='rdr-PredefinedRangeItem'
+          className={classes.predefinedRangeItem}
           style={styles['PredefinedRangeItem']}
           onClick={this.handleSelect.bind(this, name)}>
           {name}
@@ -41,19 +43,28 @@ class PredefinedRanges extends Component {
   }
 
   render() {
-    const { style } = this.props;
+    const { style, onlyClasses, classNames } = this.props;
     const { styles } = this;
 
+    const classes = { ...defaultClasses, ...classNames };
+
     return (
-      <div style={{ ...styles['PredefinedRanges'], ...style }} className='rdr-PredefinedRanges'>
-        {this.renderRangeList()}
+      <div style={!onlyClasses && { ...styles['PredefinedRanges'], ...style }} className={classes.predefinedRanges}>
+        {this.renderRangeList(classes)}
       </div>
     );
   }
 }
 
+PredefinedRanges.defaultProps = {
+  onlyClasses : false,
+  classNames  : {}
+};
+
 PredefinedRanges.propTypes = {
-  ranges : PropTypes.object.isRequired
+  ranges      : PropTypes.object.isRequired,
+  onlyClasses : PropTypes.bool,
+  classNames  : PropTypes.object
 }
 
 export default PredefinedRanges;

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 
 import parseInput from './utils/parseInput.js';
-import { defaultStyle } from './styles.js';
+import { defaultClasses } from './styles.js';
 
 class PredefinedRanges extends Component {
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,19 +1,22 @@
 export const defaultClasses = {
-  calendar            : 'rdr-Calendar',
-  monthAndYear        : 'rdr-MonthAndYear',
-  weekDays            : 'rdr-WeekDays',
-  weekDay             : 'rdr-WeekDay',
-  days                : 'rdr-Days',
-  day                 : 'rdr-Day',
-  dayActive           : 'is-selected',
-  dayPassive          : 'is-passive',
-  dayInRange          : 'is-inRange',
-  monthAndYearWrapper : 'rdr-MonthAndYear-innerWrapper',
-  prevButton          : 'rdr-MonthAndYear-button prev',
-  nextButton          : 'rdr-MonthAndYear-button next'
-  month               : 'rdr-MonthAndYear-month',
-  monthAndYearDivider : 'rdr-MonthAndYear-divider',
-  year                : 'rdr-MonthAndYear-year',
+  calendar             : 'rdr-Calendar',
+  dateRange            : 'rdr-DateRange',
+  predefinedRanges     : 'rdr-PredefinedRanges',
+  predefinedRangesItem : 'rdr-PredefinedRangeItem',
+  monthAndYear         : 'rdr-MonthAndYear',
+  weekDays             : 'rdr-WeekDays',
+  weekDay              : 'rdr-WeekDay',
+  days                 : 'rdr-Days',
+  day                  : 'rdr-Day',
+  dayActive            : 'is-selected',
+  dayPassive           : 'is-passive',
+  dayInRange           : 'is-inRange',
+  monthAndYearWrapper  : 'rdr-MonthAndYear-innerWrapper',
+  prevButton           : 'rdr-MonthAndYear-button prev',
+  nextButton           : 'rdr-MonthAndYear-button next'
+  month                : 'rdr-MonthAndYear-month',
+  monthAndYearDivider  : 'rdr-MonthAndYear-divider',
+  year                 : 'rdr-MonthAndYear-year'
 };
 
 const defaultTheme = {

--- a/src/styles.js
+++ b/src/styles.js
@@ -13,7 +13,7 @@ export const defaultClasses = {
   dayInRange           : 'is-inRange',
   monthAndYearWrapper  : 'rdr-MonthAndYear-innerWrapper',
   prevButton           : 'rdr-MonthAndYear-button prev',
-  nextButton           : 'rdr-MonthAndYear-button next'
+  nextButton           : 'rdr-MonthAndYear-button next',
   month                : 'rdr-MonthAndYear-month',
   monthAndYearDivider  : 'rdr-MonthAndYear-divider',
   year                 : 'rdr-MonthAndYear-year'

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,3 +1,21 @@
+export const defaultClasses = {
+  calendar            : 'rdr-Calendar',
+  monthAndYear        : 'rdr-MonthAndYear',
+  weekDays            : 'rdr-WeekDays',
+  weekDay             : 'rdr-WeekDay',
+  days                : 'rdr-Days',
+  day                 : 'rdr-Day',
+  dayActive           : 'is-selected',
+  dayPassive          : 'is-passive',
+  dayInRange          : 'is-inRange',
+  monthAndYearWrapper : 'rdr-MonthAndYear-innerWrapper',
+  prevButton          : 'rdr-MonthAndYear-button prev',
+  nextButton          : 'rdr-MonthAndYear-button next'
+  month               : 'rdr-MonthAndYear-month',
+  monthAndYearDivider : 'rdr-MonthAndYear-divider',
+  year                : 'rdr-MonthAndYear-year',
+};
+
 const defaultTheme = {
   DateRange : {
     display       : 'block',


### PR DESCRIPTION
This is intended to solve #12 

Each class name in the code base is now configurable via props ([much like](https://facebook.github.io/react/docs/animation.html#custom-classes))

This has the nice side effect of fully supporting [CSS Modules](https://github.com/css-modules/css-modules)

I also went ahead and added the `onlyClasses` prop discussed in the issue