### PR TITLE
Prevent default when changing month

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 *.log
 dist/
+.idea

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -106,7 +106,8 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'changeMonth',
-    value: function changeMonth(direction) {
+    value: function changeMonth(direction, event) {
+      event.preventDefault();
       var _props3 = this.props;
       var link = _props3.link;
       var linkCB = _props3.linkCB;
@@ -138,7 +139,7 @@ var Calendar = (function (_Component) {
           {
             style: _extends({}, styles['MonthButton'], { float: 'left' }),
             className: 'rdr-MonthAndYear-button prev',
-            onClick: this.changeMonth.bind(this, -1, false) },
+            onClick: this.changeMonth.bind(this, -1) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowPrev']) })
         ),
         _react2['default'].createElement(
@@ -165,7 +166,7 @@ var Calendar = (function (_Component) {
           {
             style: _extends({}, styles['MonthButton'], { float: 'right' }),
             className: 'rdr-MonthAndYear-button next',
-            onClick: this.changeMonth.bind(this, +1, false) },
+            onClick: this.changeMonth.bind(this, +1) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowNext']) })
         )
       );

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -62,7 +62,8 @@ class Calendar extends Component {
     }
   }
 
-  changeMonth(direction) {
+  changeMonth(direction, event) {
+    event.preventDefault();
     const { link, linkCB } = this.props;
 
     if (link && linkCB) {
@@ -88,7 +89,7 @@ class Calendar extends Component {
         <button
           style={{ ...styles['MonthButton'], float : 'left' }}
           className='rdr-MonthAndYear-button prev'
-          onClick={this.changeMonth.bind(this, -1, false)}>
+          onClick={this.changeMonth.bind(this, -1)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowPrev'] }}></i>
         </button>
         <span>
@@ -99,7 +100,7 @@ class Calendar extends Component {
         <button
           style={{ ...styles['MonthButton'], float : 'right' }}
           className='rdr-MonthAndYear-button next'
-          onClick={this.changeMonth.bind(this, +1, false)}>
+          onClick={this.changeMonth.bind(this, +1)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowNext'] }}></i>
         </button>
       </div>


### PR DESCRIPTION
Currently when the Calendar component is inside of a form it will submit the form, now preventing default action on changeMonth.