### PR TITLE
Revert "Configurable Classes"

### DIFF
--- a/demo/build.js
+++ b/demo/build.js
@@ -13,7 +13,8 @@ var config = {
 
   output                : {
     path                : path.join(__dirname, '/dist'),
-    filename            : '[name].js'
+    filename            : '[name].js',
+    publicPath          : '/'
   },
 
   devtool               : ((NODE_ENV==='development') ? 'source-map' : false),

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { defaultRanges, Calendar, DateRange } from '../../../lib/';
+import { defaultRanges, Calendar, DateRange } from 'react-date-range';
 import Section from 'components/Section';
 
 import 'normalize.css';

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -125,21 +125,20 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderMonthAndYear',
-    value: function renderMonthAndYear(classes) {
+    value: function renderMonthAndYear() {
       var shownDate = this.getShownDate();
       var month = _moment2['default'].months(shownDate.month());
       var year = shownDate.year();
       var styles = this.styles;
-      var onlyClasses = this.props.onlyClasses;
 
       return _react2['default'].createElement(
         'div',
-        { style: !onlyClasses && styles['MonthAndYear'], className: classes.monthAndYearWrapper },
+        { style: styles['MonthAndYear'], className: 'rdr-MonthAndYear-innerWrapper' },
         _react2['default'].createElement(
           'button',
           {
-            style: !onlyClasses && _extends({}, styles['MonthButton'], { float: 'left' }),
-            className: classes.prevButton,
+            style: _extends({}, styles['MonthButton'], { float: 'left' }),
+            className: 'rdr-MonthAndYear-button prev',
             onClick: this.changeMonth.bind(this, -1) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowPrev']) })
         ),
@@ -148,25 +147,25 @@ var Calendar = (function (_Component) {
           null,
           _react2['default'].createElement(
             'span',
-            { className: classes.month },
+            { className: 'rdr-MonthAndYear-month' },
             month
           ),
           _react2['default'].createElement(
             'span',
-            { className: classes.monthAndYearDivider },
+            { className: 'rdr-MonthAndYear-divider' },
             ' - '
           ),
           _react2['default'].createElement(
             'span',
-            { className: classes.year },
+            { className: 'rdr-MonthAndYear-year' },
             year
           )
         ),
         _react2['default'].createElement(
           'button',
           {
-            style: !onlyClasses && _extends({}, styles['MonthButton'], { float: 'right' }),
-            className: classes.nextButton,
+            style: _extends({}, styles['MonthButton'], { float: 'right' }),
+            className: 'rdr-MonthAndYear-button next',
             onClick: this.changeMonth.bind(this, +1) },
           _react2['default'].createElement('i', { style: _extends({}, styles['MonthArrow'], styles['MonthArrowNext']) })
         )
@@ -174,18 +173,17 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderWeekdays',
-    value: function renderWeekdays(classes) {
+    value: function renderWeekdays() {
       var dow = this.state.firstDayOfWeek;
       var weekdays = [];
       var styles = this.styles;
-      var onlyClasses = this.props.onlyClasses;
 
       for (var i = dow; i < 7 + dow; i++) {
         var day = _moment2['default'].weekdaysMin(i);
 
         weekdays.push(_react2['default'].createElement(
           'span',
-          { style: !onlyClasses && styles['Weekday'], className: classes.weekDay, key: day },
+          { style: styles['Weekday'], className: 'rdr-WeekDay', key: day },
           day
         ));
       }
@@ -194,14 +192,12 @@ var Calendar = (function (_Component) {
     }
   }, {
     key: 'renderDays',
-    value: function renderDays(classes) {
+    value: function renderDays() {
       var _this = this;
 
       // TODO: Split this logic into smaller chunks
       var styles = this.styles;
-      var _props4 = this.props;
-      var range = _props4.range;
-      var onlyClasses = _props4.onlyClasses;
+      var range = this.props.range;
 
       var shownDate = this.getShownDate();
       var _state = this.state;
@@ -257,9 +253,7 @@ var Calendar = (function (_Component) {
           theme: styles,
           isSelected: isSelected || isEdge,
           isInRange: isInRange,
-          key: index,
-          onlyClasses: onlyClasses,
-          classNames: classes
+          key: index
         }));
       });
     }
@@ -267,28 +261,24 @@ var Calendar = (function (_Component) {
     key: 'render',
     value: function render() {
       var styles = this.styles;
-      var classNames = this.classNames;
-      var onlyClasses = this.props.onlyClasses;
-
-      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
 
       return _react2['default'].createElement(
         'div',
-        { style: !onlyClasses && _extends({}, styles['Calendar'], this.props.style), className: classes.calendar },
+        { style: _extends({}, styles['Calendar'], this.props.style), className: 'rdr-Calendar' },
         _react2['default'].createElement(
           'div',
-          { className: classes.monthAndYear },
-          this.renderMonthAndYear(classes)
+          { className: 'rdr-MonthAndYear' },
+          this.renderMonthAndYear()
         ),
         _react2['default'].createElement(
           'div',
-          { className: classes.weekDays },
-          this.renderWeekdays(classes)
+          { className: 'rdr-WeekDays' },
+          this.renderWeekdays()
         ),
         _react2['default'].createElement(
           'div',
-          { className: classes.days },
-          this.renderDays(classes)
+          { className: 'rdr-Days' },
+          this.renderDays()
         )
       );
     }
@@ -299,9 +289,7 @@ var Calendar = (function (_Component) {
 
 Calendar.defaultProps = {
   format: 'DD/MM/YYYY',
-  theme: {},
-  onlyClasses: false,
-  classNames: {}
+  theme: {}
 };
 
 Calendar.propTypes = {
@@ -320,9 +308,7 @@ Calendar.propTypes = {
     endDate: _react.PropTypes.object
   }), _react.PropTypes.bool]),
   linkCB: _react.PropTypes.func,
-  theme: _react.PropTypes.object,
-  onlyClasses: _react.PropTypes.bool,
-  classNames: _react.PropTypes.object
+  theme: _react.PropTypes.object
 };
 
 exports['default'] = Calendar;

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -171,25 +171,19 @@ var DateRange = (function (_Component) {
       var style = _props.style;
       var calendars = _props.calendars;
       var firstDayOfWeek = _props.firstDayOfWeek;
-      var classNames = _props.classNames;
-      var onlyClasses = _props.onlyClasses;
       var _state = this.state;
       var range = _state.range;
       var link = _state.link;
       var styles = this.styles;
 
-      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
-
       return _react2['default'].createElement(
         'div',
-        { style: !onlyClasses && _extends({}, styles['DateRange'], style), className: classes.dateRange },
+        { style: _extends({}, styles['DateRange'], style), className: 'rdr-DateRange' },
         ranges && _react2['default'].createElement(_PredefinedRangesJs2['default'], {
           format: format,
           ranges: ranges,
           theme: styles,
-          onSelect: this.handleSelect.bind(this),
-          onlyClasses: onlyClasses,
-          classNames: classes }),
+          onSelect: this.handleSelect.bind(this) }),
         (function () {
           var _calendars = [];
           for (var i = Number(calendars) - 1; i >= 0; i--) {
@@ -202,9 +196,7 @@ var DateRange = (function (_Component) {
               format: format,
               firstDayOfWeek: firstDayOfWeek,
               theme: styles,
-              onChange: _this.handleSelect.bind(_this),
-              onlyClasses: onlyClasses,
-              classNames: classes }));
+              onChange: _this.handleSelect.bind(_this) }));
           }
           return _calendars;
         })()
@@ -219,9 +211,7 @@ DateRange.defaultProps = {
   linkedCalendars: false,
   theme: {},
   format: 'DD/MM/YYYY',
-  calendars: 2,
-  onlyClasses: false,
-  classNames: {}
+  calendars: 2
 };
 
 DateRange.propTypes = {
@@ -237,9 +227,7 @@ DateRange.propTypes = {
   linkedCalendars: _react.PropTypes.bool,
   theme: _react.PropTypes.object,
   onInit: _react.PropTypes.func,
-  onChange: _react.PropTypes.func,
-  onlyClasses: _react.PropTypes.bool,
-  classNames: _react.PropTypes.object
+  onChange: _react.PropTypes.func
 };
 
 exports['default'] = DateRange;

--- a/lib/DayCell.js
+++ b/lib/DayCell.js
@@ -12,8 +12,6 @@ var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_ag
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -21,12 +19,6 @@ function _inherits(subClass, superClass) { if (typeof superClass !== 'function' 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
-
-var _classnames2 = require('classnames');
-
-var _classnames3 = _interopRequireDefault(_classnames2);
-
-var _stylesJs = require('./styles.js');
 
 var DayCell = (function (_Component) {
   _inherits(DayCell, _Component);
@@ -102,27 +94,28 @@ var DayCell = (function (_Component) {
     }
   }, {
     key: 'getClassNames',
-    value: function getClassNames(classes) {
-      var _classnames;
-
+    value: function getClassNames() {
       var _props2 = this.props;
       var isSelected = _props2.isSelected;
       var isInRange = _props2.isInRange;
       var isPassive = _props2.isPassive;
 
-      return (0, _classnames3['default'])((_classnames = {}, _defineProperty(_classnames, classes.day, true), _defineProperty(_classnames, classes.dayActive, isSelected), _defineProperty(_classnames, classes.dayPassive, isPassive), _defineProperty(_classnames, classes.dayInRange, isInRange), _classnames));
+      var classNames = 'rdr-Day ';
+
+      classNames = isSelected ? classNames + 'is-selected ' : classNames;
+      classNames = isInRange ? classNames + 'is-inRange ' : classNames;
+      classNames = isPassive ? classNames + 'is-passive ' : classNames;
+
+      return classNames;
     }
   }, {
     key: 'render',
     value: function render() {
-      var _props3 = this.props;
-      var dayMoment = _props3.dayMoment;
-      var onlyClasses = _props3.onlyClasses;
-      var classNames = _props3.classNames;
       var styles = this.styles;
+      var dayMoment = this.props.dayMoment;
 
       var stateStyle = this.getStateStyles();
-      var classes = this.getClassNames(classNames);
+      var classNames = this.getClassNames();
 
       return _react2['default'].createElement(
         'span',
@@ -132,8 +125,8 @@ var DayCell = (function (_Component) {
           onMouseDown: this.handleMouseEvent.bind(this),
           onMouseUp: this.handleMouseEvent.bind(this),
           onClick: this.handleSelect.bind(this),
-          className: classes,
-          style: !onlyClasses && _extends({}, styles['Day'], stateStyle) },
+          className: classNames,
+          style: _extends({}, styles['Day'], stateStyle) },
         dayMoment.date()
       );
     }
@@ -143,8 +136,7 @@ var DayCell = (function (_Component) {
 })(_react.Component);
 
 DayCell.defaultProps = {
-  theme: { 'Day': {} },
-  onlyClasses: false
+  theme: { 'Day': {} }
 };
 
 DayCell.propTypes = {
@@ -155,9 +147,7 @@ DayCell.propTypes = {
   isPassive: _react.PropTypes.bool,
   theme: _react.PropTypes.shape({
     Day: _react.PropTypes.object.isRequired
-  }).isRequired,
-  onlyClasses: _react.PropTypes.bool,
-  classNames: _react.PropTypes.object
+  }).isRequired
 };
 
 exports['default'] = DayCell;

--- a/lib/PredefinedRanges.js
+++ b/lib/PredefinedRanges.js
@@ -20,15 +20,13 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _moment = require('moment');
-
-var _moment2 = _interopRequireDefault(_moment);
-
 var _utilsParseInputJs = require('./utils/parseInput.js');
 
 var _utilsParseInputJs2 = _interopRequireDefault(_utilsParseInputJs);
 
-var _stylesJs = require('./styles.js');
+var _moment = require('moment');
+
+var _moment2 = _interopRequireDefault(_moment);
 
 var PredefinedRanges = (function (_Component) {
   _inherits(PredefinedRanges, _Component);
@@ -56,7 +54,7 @@ var PredefinedRanges = (function (_Component) {
     }
   }, {
     key: 'renderRangeList',
-    value: function renderRangeList(classes) {
+    value: function renderRangeList() {
       var _this = this;
 
       var ranges = this.props.ranges;
@@ -68,7 +66,7 @@ var PredefinedRanges = (function (_Component) {
           {
             href: '#',
             key: 'range-' + name,
-            className: classes.predefinedRangeItem,
+            className: 'rdr-PredefinedRangeItem',
             style: styles['PredefinedRangeItem'],
             onClick: _this.handleSelect.bind(_this, name) },
           name
@@ -78,18 +76,13 @@ var PredefinedRanges = (function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props = this.props;
-      var style = _props.style;
-      var onlyClasses = _props.onlyClasses;
-      var classNames = _props.classNames;
+      var style = this.props.style;
       var styles = this.styles;
-
-      var classes = _extends({}, _stylesJs.defaultClasses, classNames);
 
       return _react2['default'].createElement(
         'div',
-        { style: !onlyClasses && _extends({}, styles['PredefinedRanges'], style), className: classes.predefinedRanges },
-        this.renderRangeList(classes)
+        { style: _extends({}, styles['PredefinedRanges'], style), className: 'rdr-PredefinedRanges' },
+        this.renderRangeList()
       );
     }
   }]);
@@ -97,15 +90,8 @@ var PredefinedRanges = (function (_Component) {
   return PredefinedRanges;
 })(_react.Component);
 
-PredefinedRanges.defaultProps = {
-  onlyClasses: false,
-  classNames: {}
-};
-
 PredefinedRanges.propTypes = {
-  ranges: _react.PropTypes.object.isRequired,
-  onlyClasses: _react.PropTypes.bool,
-  classNames: _react.PropTypes.object
+  ranges: _react.PropTypes.object.isRequired
 };
 
 exports['default'] = PredefinedRanges;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -6,28 +6,6 @@ Object.defineProperty(exports, '__esModule', {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var defaultClasses = {
-  calendar: 'rdr-Calendar',
-  dateRange: 'rdr-DateRange',
-  predefinedRanges: 'rdr-PredefinedRanges',
-  predefinedRangesItem: 'rdr-PredefinedRangeItem',
-  monthAndYear: 'rdr-MonthAndYear',
-  weekDays: 'rdr-WeekDays',
-  weekDay: 'rdr-WeekDay',
-  days: 'rdr-Days',
-  day: 'rdr-Day',
-  dayActive: 'is-selected',
-  dayPassive: 'is-passive',
-  dayInRange: 'is-inRange',
-  monthAndYearWrapper: 'rdr-MonthAndYear-innerWrapper',
-  prevButton: 'rdr-MonthAndYear-button prev',
-  nextButton: 'rdr-MonthAndYear-button next',
-  month: 'rdr-MonthAndYear-month',
-  monthAndYearDivider: 'rdr-MonthAndYear-divider',
-  year: 'rdr-MonthAndYear-year'
-};
-
-exports.defaultClasses = defaultClasses;
 var defaultTheme = {
   DateRange: {
     display: 'block',
@@ -213,3 +191,5 @@ exports['default'] = function () {
     PredefinedRangeItem: _extends({}, defaultTheme.PredefinedRangeItem, customTheme.PredefinedRangeItem)
   };
 };
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "url": "http://github.com/Adphorus/react-date-range/issues"
   },
   "dependencies": {
-    "classnames": "^2.2.1",
     "moment": "^2.10.6",
     "react": ">=0.13.0"
   },

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 import parseInput from './utils/parseInput.js';
 import DayCell from './DayCell.js';
-import getTheme, { defaultClasses } from './styles.js';
+import getTheme from './styles.js';
 
 function checkRange(dayMoment, range) {
   return (
@@ -78,29 +78,28 @@ class Calendar extends Component {
     });
   }
 
-  renderMonthAndYear(classes) {
-    const shownDate       = this.getShownDate();
-    const month           = moment.months(shownDate.month());
-    const year            = shownDate.year();
-    const { styles }      = this;
-    const { onlyClasses } = this.props;
+  renderMonthAndYear() {
+    const shownDate  = this.getShownDate();
+    const month      = moment.months(shownDate.month());
+    const year       = shownDate.year();
+    const { styles } = this;
 
     return (
-      <div style={!onlyClasses && styles['MonthAndYear']} className={classes.monthAndYearWrapper}>
+      <div style={styles['MonthAndYear']} className='rdr-MonthAndYear-innerWrapper'>
         <button
-          style={!onlyClasses && { ...styles['MonthButton'], float : 'left' }}
-          className={classes.prevButton}
+          style={{ ...styles['MonthButton'], float : 'left' }}
+          className='rdr-MonthAndYear-button prev'
           onClick={this.changeMonth.bind(this, -1)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowPrev'] }}></i>
         </button>
         <span>
-          <span className={classes.month}>{month}</span>
-          <span className={classes.monthAndYearDivider}> - </span>
-          <span className={classes.year}>{year}</span>
+          <span className='rdr-MonthAndYear-month'>{month}</span>
+          <span className='rdr-MonthAndYear-divider'> - </span>
+          <span className='rdr-MonthAndYear-year'>{year}</span>
         </span>
         <button
-          style={!onlyClasses && { ...styles['MonthButton'], float : 'right' }}
-          className={classes.nextButton}
+          style={{ ...styles['MonthButton'], float : 'right' }}
+          className='rdr-MonthAndYear-button next'
           onClick={this.changeMonth.bind(this, +1)}>
           <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowNext'] }}></i>
         </button>
@@ -108,28 +107,27 @@ class Calendar extends Component {
     )
   }
 
-  renderWeekdays(classes) {
-    const dow             = this.state.firstDayOfWeek;
-    const weekdays        = [];
-    const { styles }      = this;
-    const { onlyClasses } = this.props;
+  renderWeekdays() {
+    const dow        = this.state.firstDayOfWeek;
+    const weekdays   = [];
+    const { styles } = this;
 
     for (let i = dow; i < 7 + dow; i++) {
       const day = moment.weekdaysMin(i);
 
       weekdays.push(
-        <span style={!onlyClasses && styles['Weekday']} className={classes.weekDay} key={day}>{day}</span>
+        <span style={styles['Weekday']} className='rdr-WeekDay' key={day}>{day}</span>
       );
     }
 
     return weekdays;
   }
 
-  renderDays(classes) {
+  renderDays() {
     // TODO: Split this logic into smaller chunks
     const { styles }               = this;
 
-    const { range, onlyClasses }   = this.props;
+    const { range }                = this.props;
 
     const shownDate                = this.getShownDate();
     const { date, firstDayOfWeek } = this.state;
@@ -182,34 +180,27 @@ class Calendar extends Component {
           isSelected={ isSelected || isEdge }
           isInRange={ isInRange }
           key={ index }
-          onlyClasses = { onlyClasses }
-          classNames = { classes }
         />
       );
     })
   }
 
   render() {
-    const { styles, classNames } = this;
-    const { onlyClasses }        = this.props;
-
-    const classes = { ...defaultClasses, ...classNames };
+    const { styles } = this;
 
     return (
-      <div style={ !onlyClasses && { ...styles['Calendar'], ...this.props.style }} className={classes.calendar}>
-        <div className={classes.monthAndYear}>{ this.renderMonthAndYear(classes) }</div>
-        <div className={classes.weekDays}>{ this.renderWeekdays(classes) }</div>
-        <div className={classes.days}>{ this.renderDays(classes) }</div>
+      <div style={{ ...styles['Calendar'], ...this.props.style }} className='rdr-Calendar'>
+        <div className='rdr-MonthAndYear'>{ this.renderMonthAndYear() }</div>
+        <div className='rdr-WeekDays'>{ this.renderWeekdays() }</div>
+        <div className='rdr-Days'>{ this.renderDays() }</div>
       </div>
     )
   }
 }
 
 Calendar.defaultProps = {
-  format      : 'DD/MM/YYYY',
-  theme       : {},
-  onlyClasses : false,
-  classNames  : {}
+  format    : 'DD/MM/YYYY',
+  theme     : {},
 }
 
 Calendar.propTypes = {
@@ -229,8 +220,6 @@ Calendar.propTypes = {
   }), PropTypes.bool]),
   linkCB         : PropTypes.func,
   theme          : PropTypes.object,
-  onlyClasses    : PropTypes.bool,
-  classNames     : PropTypes.object
 }
 
 export default Calendar;

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import parseInput from './utils/parseInput.js';
 import Calendar from './Calendar.js';
 import PredefinedRanges from './PredefinedRanges.js';
-import getTheme, { defaultClasses } from './styles.js';
+import getTheme from './styles.js';
 
 class DateRange extends Component {
 
@@ -108,22 +108,18 @@ class DateRange extends Component {
   }
 
   render() {
-    const { ranges, format, linkedCalendars, style, calendars, firstDayOfWeek, classNames, onlyClasses } = this.props;
+    const { ranges, format, linkedCalendars, style, calendars, firstDayOfWeek } = this.props;
     const { range, link } = this.state;
     const { styles } = this;
 
-    const classes = { ...defaultClasses, ...classNames };
-
     return (
-      <div style={!onlyClasses && { ...styles['DateRange'], ...style }} className={classes.dateRange}>
+      <div style={{ ...styles['DateRange'], ...style }} className='rdr-DateRange'>
         { ranges && (
           <PredefinedRanges
             format={ format }
             ranges={ ranges }
             theme={ styles }
-            onSelect={this.handleSelect.bind(this)}
-            onlyClasses={ onlyClasses }
-            classNames={ classes } />
+            onSelect={this.handleSelect.bind(this)} />
         )}
 
         {()=>{
@@ -139,9 +135,7 @@ class DateRange extends Component {
                 format={ format }
                 firstDayOfWeek={ firstDayOfWeek }
                 theme={ styles }
-                onChange={ this.handleSelect.bind(this) }
-                onlyClasses={ onlyClasses }
-                classNames={ classes }  />
+                onChange={ this.handleSelect.bind(this) }  />
             );
           }
           return _calendars;
@@ -155,9 +149,7 @@ DateRange.defaultProps = {
   linkedCalendars : false,
   theme           : {},
   format          : 'DD/MM/YYYY',
-  calendars       : 2,
-  onlyClasses     : false,
-  classNames      : {}
+  calendars       : 2
 }
 
 DateRange.propTypes = {
@@ -174,8 +166,6 @@ DateRange.propTypes = {
   theme           : PropTypes.object,
   onInit          : PropTypes.func,
   onChange        : PropTypes.func,
-  onlyClasses     : PropTypes.bool,
-  classNames      : PropTypes.object
 }
 
 export default DateRange;

--- a/src/DayCell.js
+++ b/src/DayCell.js
@@ -1,7 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import classnames from 'classnames';
-
-import { defaultClasses } from './styles.js';
 
 class DayCell extends Component {
 
@@ -70,24 +67,23 @@ class DayCell extends Component {
     };
   }
 
-  getClassNames(classes) {
+  getClassNames() {
     const { isSelected, isInRange, isPassive } = this.props;
 
-    return classnames({
-      [classes.day]       : true,
-      [classes.dayActive] : isSelected,
-      [classes.dayPassive]: isPassive,
-      [classes.dayInRange]: isInRange
-    });
+    let classNames = 'rdr-Day ';
 
+    classNames = (isSelected) ? classNames + 'is-selected ' : classNames;
+    classNames = (isInRange) ? classNames + 'is-inRange ' : classNames;
+    classNames = (isPassive) ? classNames + 'is-passive ' : classNames;
+
+    return classNames;
   }
 
   render() {
-    const { dayMoment, onlyClasses, classNames } = this.props;
-
-    const { styles } = this;
-    const stateStyle = this.getStateStyles();
-    const classes    = this.getClassNames(classNames);
+    const { styles }    = this;
+    const { dayMoment } = this.props;
+    const stateStyle    = this.getStateStyles();
+    const classNames    = this.getClassNames();
 
     return (
       <span
@@ -96,8 +92,8 @@ class DayCell extends Component {
         onMouseDown={ this.handleMouseEvent.bind(this) }
         onMouseUp={ this.handleMouseEvent.bind(this) }
         onClick={ this.handleSelect.bind(this) }
-        className={ classes }
-        style={!onlyClasses && {...styles['Day'], ...stateStyle}}>
+        className={ classNames }
+        style={{...styles['Day'], ...stateStyle}}>
         { dayMoment.date() }
       </span>
     );
@@ -105,21 +101,18 @@ class DayCell extends Component {
 }
 
 DayCell.defaultProps = {
-  theme       : { 'Day' : {} },
-  onlyClasses : false
+  theme      : { 'Day' : {} }
 }
 
 DayCell.propTypes = {
-  dayMoment   : PropTypes.object.isRequired,
-  onSelect    : PropTypes.func,
-  isSelected  : PropTypes.bool,
-  isInRange   : PropTypes.bool,
-  isPassive   : PropTypes.bool,
-  theme       : PropTypes.shape({
-    Day       : PropTypes.object.isRequired
+  dayMoment  : PropTypes.object.isRequired,
+  onSelect   : PropTypes.func,
+  isSelected : PropTypes.bool,
+  isInRange  : PropTypes.bool,
+  isPassive  : PropTypes.bool,
+  theme      : PropTypes.shape({
+    Day      : PropTypes.object.isRequired
   }).isRequired,
-  onlyClasses : PropTypes.bool,
-  classNames  : PropTypes.object
 }
 
 export default DayCell;

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -1,8 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import moment from 'moment';
-
 import parseInput from './utils/parseInput.js';
-import { defaultClasses } from './styles.js';
+import moment from 'moment';
 
 class PredefinedRanges extends Component {
 
@@ -24,7 +22,7 @@ class PredefinedRanges extends Component {
     });
   }
 
-  renderRangeList(classes) {
+  renderRangeList() {
     const { ranges } = this.props;
     const { styles } = this;
 
@@ -33,7 +31,7 @@ class PredefinedRanges extends Component {
         <a
           href='#'
           key={'range-' + name}
-          className={classes.predefinedRangeItem}
+          className='rdr-PredefinedRangeItem'
           style={styles['PredefinedRangeItem']}
           onClick={this.handleSelect.bind(this, name)}>
           {name}
@@ -43,28 +41,19 @@ class PredefinedRanges extends Component {
   }
 
   render() {
-    const { style, onlyClasses, classNames } = this.props;
+    const { style } = this.props;
     const { styles } = this;
 
-    const classes = { ...defaultClasses, ...classNames };
-
     return (
-      <div style={!onlyClasses && { ...styles['PredefinedRanges'], ...style }} className={classes.predefinedRanges}>
-        {this.renderRangeList(classes)}
+      <div style={{ ...styles['PredefinedRanges'], ...style }} className='rdr-PredefinedRanges'>
+        {this.renderRangeList()}
       </div>
     );
   }
 }
 
-PredefinedRanges.defaultProps = {
-  onlyClasses : false,
-  classNames  : {}
-};
-
 PredefinedRanges.propTypes = {
-  ranges      : PropTypes.object.isRequired,
-  onlyClasses : PropTypes.bool,
-  classNames  : PropTypes.object
+  ranges : PropTypes.object.isRequired
 }
 
 export default PredefinedRanges;

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,24 +1,3 @@
-export const defaultClasses = {
-  calendar             : 'rdr-Calendar',
-  dateRange            : 'rdr-DateRange',
-  predefinedRanges     : 'rdr-PredefinedRanges',
-  predefinedRangesItem : 'rdr-PredefinedRangeItem',
-  monthAndYear         : 'rdr-MonthAndYear',
-  weekDays             : 'rdr-WeekDays',
-  weekDay              : 'rdr-WeekDay',
-  days                 : 'rdr-Days',
-  day                  : 'rdr-Day',
-  dayActive            : 'is-selected',
-  dayPassive           : 'is-passive',
-  dayInRange           : 'is-inRange',
-  monthAndYearWrapper  : 'rdr-MonthAndYear-innerWrapper',
-  prevButton           : 'rdr-MonthAndYear-button prev',
-  nextButton           : 'rdr-MonthAndYear-button next',
-  month                : 'rdr-MonthAndYear-month',
-  monthAndYearDivider  : 'rdr-MonthAndYear-divider',
-  year                 : 'rdr-MonthAndYear-year'
-};
-
 const defaultTheme = {
   DateRange : {
     display       : 'block',


### PR DESCRIPTION
Reverts Adphorus/react-date-range#17

I did try it locally and `onlyClasses={ true }` throwed: 
```
Uncaught Error: Invariant Violation: The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.
```

i think this is because of `{ !onlyClasses && {... }` is returning `false` and the style prop becoming `style={false}`