### PR TITLE
Enabled "onlyClasses" option for PredefinedRangesItem, MonthArrowPrev, and MonthArrowNext

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -101,7 +101,7 @@ class Calendar extends Component {
           style={onlyClasses ? undefined : { ...styles['MonthButton'], float : 'left' }}
           className={classes.prevButton}
           onClick={this.changeMonth.bind(this, -1)}>
-          <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowPrev'] }}></i>
+          <i style={onlyClasses ? undefined : { ...styles['MonthArrow'], ...styles['MonthArrowPrev'] }}></i>
         </button>
         <span>
           <span className={classes.month}>{month}</span>
@@ -112,7 +112,7 @@ class Calendar extends Component {
           style={onlyClasses ? undefined : { ...styles['MonthButton'], float : 'right' }}
           className={classes.nextButton}
           onClick={this.changeMonth.bind(this, +1)}>
-          <i style={{ ...styles['MonthArrow'], ...styles['MonthArrowNext'] }}></i>
+          <i style={onlyClasses ? undefined : { ...styles['MonthArrow'], ...styles['MonthArrowNext'] }}></i>
         </button>
       </div>
     )

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -42,7 +42,7 @@ class PredefinedRanges extends Component {
           href='#'
           key={'range-' + name}
           className={classes.predefinedRangesItem + (active ? ' active' : '')}
-          style={ style }
+          style={ onlyClasses ? undefined : style }
           onClick={this.handleSelect.bind(this, name)}
         >
           {name}


### PR DESCRIPTION
Great component! When using the "onlyClasses" option, there were just a couple inner components still using inline styles.