### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ class MyComponent extends Component {
 ```
 
 ###### Available Options (props)
-* **date:** *(String, Moment.js object, Function)* - default: today
+* **startDate:** *(String, Moment.js object, Function)* - default: today
+* **endDate:** *(String, Moment.js object, Function)* - default: today
 * **format:** *(String)* - default: DD/MM/YYY
 * **firstDayOfWeek** *(Number)* - default: [moment.localeData().firstDayOfWeek()](http://momentjs.com/docs/#/i18n/locale-data/)
 * **theme:** *(Object)* see [Demo's source](https://github.com/Adphorus/react-date-range/blob/master/demo/src/components/Main.js#L143)


### PR DESCRIPTION
The props for DateRange are missing the 2 parameters to initialize the range value (startDate and endDate).