### PR TITLE
Stopped parseInput from mutating props

### DIFF
--- a/lib/utils/parseInput.js
+++ b/lib/utils/parseInput.js
@@ -21,7 +21,7 @@ function parseInput(input, format) {
   } else if (typeof input === 'function') {
     output = parseInput(input((0, _moment2['default'])().startOf('day')), format);
   } else if (input._isAMomentObject) {
-    output = input.startOf('day').clone();
+    output = input.clone().startOf('day');
   }
 
   return output;


### PR DESCRIPTION
This is a tiny change, but after being confused writing component tests for a while, I found this and I figured it was less work to change it than it was to write an issue.

Thanks for the component! It works really well.