### PR TITLE
use startOf and endOf for date selection and ranges

### DIFF
--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -43,17 +43,17 @@ function checkRange(dayMoment, range) {
 function checkStartEdge(dayMoment, range) {
   var startDate = range.startDate;
 
-  return dayMoment.isSame(startDate);
+  return dayMoment.startOf('day').isSame(startDate.startOf('day'));
 }
 
 function checkEndEdge(dayMoment, range) {
   var endDate = range.endDate;
 
-  return dayMoment.isSame(endDate);
+  return dayMoment.endOf('day').isSame(endDate.endOf('day'));
 }
 
 function isOusideMinMax(dayMoment, minDate, maxDate, format) {
-  return minDate && dayMoment.isBefore((0, _utilsParseInputJs2['default'])(minDate, format)) || maxDate && dayMoment.isAfter((0, _utilsParseInputJs2['default'])(maxDate, format));
+  return minDate && dayMoment.isBefore((0, _utilsParseInputJs2['default'])(minDate, format, 'startOf')) || maxDate && dayMoment.isAfter((0, _utilsParseInputJs2['default'])(maxDate, format, 'endOf'));
 }
 
 var Calendar = (function (_Component) {
@@ -70,7 +70,7 @@ var Calendar = (function (_Component) {
     var offset = props.offset;
     var firstDayOfWeek = props.firstDayOfWeek;
 
-    var date = (0, _utilsParseInputJs2['default'])(props.date, format);
+    var date = (0, _utilsParseInputJs2['default'])(props.date, format, 'startOf');
     var state = {
       date: date,
       shownDate: (range && range['endDate'] || date).clone().add(offset, 'months'),
@@ -255,7 +255,7 @@ var Calendar = (function (_Component) {
         days.push({ dayMoment: dayMoment, isPassive: true });
       }
 
-      var today = (0, _moment2['default'])().startOf('day');
+      var today = (0, _moment2['default'])().endOf('day');
       return days.map(function (data, index) {
         var dayMoment = data.dayMoment;
         var isPassive = data.isPassive;

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -52,8 +52,8 @@ var DateRange = (function (_Component) {
     var linkedCalendars = props.linkedCalendars;
     var theme = props.theme;
 
-    var startDate = (0, _utilsParseInputJs2['default'])(props.startDate, format);
-    var endDate = (0, _utilsParseInputJs2['default'])(props.endDate, format);
+    var startDate = (0, _utilsParseInputJs2['default'])(props.startDate, format, 'startOf');
+    var endDate = (0, _utilsParseInputJs2['default'])(props.endDate, format, 'endOf');
 
     this.state = {
       range: { startDate: startDate, endDate: endDate },
@@ -144,10 +144,10 @@ var DateRange = (function (_Component) {
       // Whenever date props changes, update state with parsed variant
       if (newProps.startDate || newProps.endDate) {
         var format = newProps.format || this.props.format;
-        var startDate = newProps.startDate && (0, _utilsParseInputJs2['default'])(newProps.startDate, format);
-        var endDate = newProps.endDate && (0, _utilsParseInputJs2['default'])(newProps.endDate, format);
-        var oldStartDate = this.props.startDate && (0, _utilsParseInputJs2['default'])(this.props.startDate, format);
-        var oldEndDate = this.props.endDate && (0, _utilsParseInputJs2['default'])(this.props.endDate, format);
+        var startDate = newProps.startDate && (0, _utilsParseInputJs2['default'])(newProps.startDate, format, 'startOf');
+        var endDate = newProps.endDate && (0, _utilsParseInputJs2['default'])(newProps.endDate, format, 'endOf');
+        var oldStartDate = this.props.startDate && (0, _utilsParseInputJs2['default'])(this.props.startDate, format, 'startOf');
+        var oldEndDate = this.props.endDate && (0, _utilsParseInputJs2['default'])(this.props.endDate, format, 'endOf');
 
         if (!startDate.isSame(oldStartDate) || !endDate.isSame(oldEndDate)) {
           this.setRange({

--- a/lib/PredefinedRanges.js
+++ b/lib/PredefinedRanges.js
@@ -49,8 +49,8 @@ var PredefinedRanges = (function (_Component) {
       var range = this.props.ranges[name];
 
       this.props.onSelect({
-        startDate: (0, _utilsParseInputJs2['default'])(range['startDate']),
-        endDate: (0, _utilsParseInputJs2['default'])(range['endDate'])
+        startDate: (0, _utilsParseInputJs2['default'])(range['startDate'], null, 'startOf'),
+        endDate: (0, _utilsParseInputJs2['default'])(range['endDate'], null, 'endOf')
       }, PredefinedRanges);
     }
   }, {
@@ -65,7 +65,7 @@ var PredefinedRanges = (function (_Component) {
       var styles = this.styles;
 
       return Object.keys(ranges).map((function (name) {
-        var active = (0, _utilsParseInputJs2['default'])(ranges[name].startDate).isSame(range.startDate) && (0, _utilsParseInputJs2['default'])(ranges[name].endDate).isSame(range.endDate);
+        var active = (0, _utilsParseInputJs2['default'])(ranges[name].startDate, null, 'startOf').isSame(range.startDate) && (0, _utilsParseInputJs2['default'])(ranges[name].endDate, null, 'endOf').isSame(range.endDate);
 
         var style = _extends({}, styles['PredefinedRangesItem'], active ? styles['PredefinedRangesItemActive'] : {});
 

--- a/lib/utils/parseInput.js
+++ b/lib/utils/parseInput.js
@@ -11,17 +11,17 @@ var _moment = require('moment');
 
 var _moment2 = _interopRequireDefault(_moment);
 
-function parseInput(input, format) {
+function parseInput(input, format, timeOfDay) {
   var output = null;
 
   if (typeof input === 'undefined' || typeof input === 'null' || !input || input === '') {
-    output = (0, _moment2['default'])().startOf('day');
+    output = (0, _moment2['default'])()[timeOfDay]('day');
   } else if (typeof input === 'string') {
-    output = (0, _moment2['default'])(input, format).startOf('day');
+    output = (0, _moment2['default'])(input, format)[timeOfDay]('day');
   } else if (typeof input === 'function') {
-    output = parseInput(input((0, _moment2['default'])().startOf('day')), format);
+    output = parseInput(input((0, _moment2['default'])()[timeOfDay]('day')), format, timeOfDay);
   } else if (input._isAMomentObject) {
-    output = input.clone().startOf('day');
+    output = input[timeOfDay]('day').clone();
   }
 
   return output;

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -14,19 +14,19 @@ function checkRange(dayMoment, range) {
 function checkStartEdge(dayMoment, range) {
   const { startDate } = range;
 
-  return dayMoment.isSame(startDate);
+  return dayMoment.startOf('day').isSame(startDate.startOf('day'));
 }
 
 function checkEndEdge(dayMoment, range) {
   const { endDate } = range;
 
-  return dayMoment.isSame(endDate);
+  return dayMoment.endOf('day').isSame(endDate.endOf('day'));
 }
 
 function isOusideMinMax(dayMoment, minDate, maxDate, format) {
   return (
-    (minDate && dayMoment.isBefore(parseInput(minDate, format))) ||
-    (maxDate && dayMoment.isAfter(parseInput(maxDate, format)))
+    (minDate && dayMoment.isBefore(parseInput(minDate, format, 'startOf'))) ||
+    (maxDate && dayMoment.isAfter(parseInput(maxDate, format, 'endOf')))
   )
 }
 
@@ -37,7 +37,7 @@ class Calendar extends Component {
 
     const { format, range, theme, offset, firstDayOfWeek } = props;
 
-    const date = parseInput(props.date, format)
+    const date = parseInput(props.date, format, 'startOf')
     const state = {
       date,
       shownDate : (range && range['endDate'] || date).clone().add(offset, 'months'),
@@ -178,7 +178,7 @@ class Calendar extends Component {
       days.push({ dayMoment, isPassive : true });
     }
 
-    const today = moment().startOf('day');
+    const today = moment().endOf('day');
     return days.map((data, index) => {
       const { dayMoment, isPassive } = data;
       const isSelected    = !range && (dayMoment.unix() === dateUnix);

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -12,8 +12,8 @@ class DateRange extends Component {
 
     const { format, linkedCalendars, theme } = props;
 
-    const startDate = parseInput(props.startDate, format);
-    const endDate   = parseInput(props.endDate, format);
+    const startDate = parseInput(props.startDate, format, 'startOf');
+    const endDate   = parseInput(props.endDate, format, 'endOf');
 
     this.state = {
       range     : { startDate, endDate },
@@ -91,10 +91,10 @@ class DateRange extends Component {
     // Whenever date props changes, update state with parsed variant
     if (newProps.startDate || newProps.endDate) {
       const format       = newProps.format || this.props.format;
-      const startDate    = newProps.startDate   && parseInput(newProps.startDate, format);
-      const endDate      = newProps.endDate     && parseInput(newProps.endDate, format);
-      const oldStartDate = this.props.startDate && parseInput(this.props.startDate, format);
-      const oldEndDate   = this.props.endDate   && parseInput(this.props.endDate, format);
+      const startDate    = newProps.startDate   && parseInput(newProps.startDate, format, 'startOf');
+      const endDate      = newProps.endDate     && parseInput(newProps.endDate, format, 'endOf');
+      const oldStartDate = this.props.startDate && parseInput(this.props.startDate, format, 'startOf');
+      const oldEndDate   = this.props.endDate   && parseInput(this.props.endDate, format, 'endOf');
 
       if (!startDate.isSame(oldStartDate) || !endDate.isSame(oldEndDate)) {
         this.setRange({

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -17,8 +17,8 @@ class PredefinedRanges extends Component {
     const range = this.props.ranges[name];
 
     this.props.onSelect({
-      startDate : parseInput(range['startDate']),
-      endDate   : parseInput(range['endDate']),
+      startDate : parseInput(range['startDate'], null, 'startOf'),
+      endDate   : parseInput(range['endDate'], null, 'endOf'),
     }, PredefinedRanges);
   }
 
@@ -28,8 +28,8 @@ class PredefinedRanges extends Component {
 
     return Object.keys(ranges).map(name => {
       const active = (
-        parseInput(ranges[name].startDate).isSame(range.startDate) &&
-        parseInput(ranges[name].endDate).isSame(range.endDate)
+        parseInput(ranges[name].startDate, null, 'startOf').isSame(range.startDate) &&
+        parseInput(ranges[name].endDate, null, 'endOf').isSame(range.endDate)
       );
 
       const style = {

--- a/src/utils/parseInput.js
+++ b/src/utils/parseInput.js
@@ -1,16 +1,16 @@
 import moment from 'moment';
 
-export default function parseInput(input, format) {
+export default function parseInput(input, format, timeOfDay) {
   let output = null;
 
   if (typeof input === 'undefined' ||  typeof input === 'null' || !input || input === '') {
-    output = moment().startOf('day');
+    output = moment()[timeOfDay]('day');
   } else if (typeof input === 'string') {
-    output = moment(input, format).startOf('day');
+    output = moment(input, format)[timeOfDay]('day');
   } else if (typeof input === 'function') {
-    output = parseInput( input(moment().startOf('day')) , format);
+    output = parseInput( input(moment()[timeOfDay]('day')) , format, timeOfDay);
   } else if (input._isAMomentObject) {
-    output = input.startOf('day').clone();
+    output = input[timeOfDay]('day').clone();
   }
 
   return output;


### PR DESCRIPTION
I noticed that all dates are being converted using `startOf` which creates issues for applications using up-to-the-minute timestamps for graphing data. This does not break the previous behavior/experience and allows for the above mentioned use-case. 
