### PR TITLE
Add locale property

### DIFF
--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -69,6 +69,11 @@ var Calendar = (function (_Component) {
     var theme = props.theme;
     var offset = props.offset;
     var firstDayOfWeek = props.firstDayOfWeek;
+    var locale = props.locale;
+
+    if (locale) {
+      _moment2['default'].locale(locale);
+    }
 
     var date = (0, _utilsParseInputJs2['default'])(props.date, format);
     var state = {
@@ -346,7 +351,8 @@ Calendar.propTypes = {
   linkCB: _react.PropTypes.func,
   theme: _react.PropTypes.object,
   onlyClasses: _react.PropTypes.bool,
-  classNames: _react.PropTypes.object
+  classNames: _react.PropTypes.object,
+  locale: _react.PropTypes.string
 };
 
 exports['default'] = Calendar;

--- a/lib/utils/parseInput.js
+++ b/lib/utils/parseInput.js
@@ -21,7 +21,7 @@ function parseInput(input, format) {
   } else if (typeof input === 'function') {
     output = parseInput(input((0, _moment2['default'])().startOf('day')), format);
   } else if (input._isAMomentObject) {
-    output = input.clone().startOf('day');
+    output = input.startOf('day').clone();
   }
 
   return output;

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -35,7 +35,11 @@ class Calendar extends Component {
   constructor(props, context) {
     super(props, context);
 
-    const { format, range, theme, offset, firstDayOfWeek } = props;
+    const { format, range, theme, offset, firstDayOfWeek, locale } = props;
+
+    if(locale) {
+      moment.locale(locale);
+    }
 
     const date = parseInput(props.date, format)
     const state = {
@@ -251,7 +255,8 @@ Calendar.propTypes = {
   linkCB         : PropTypes.func,
   theme          : PropTypes.object,
   onlyClasses    : PropTypes.bool,
-  classNames     : PropTypes.object
+  classNames     : PropTypes.object,
+  locale         : PropTypes.string
 }
 
 export default Calendar;


### PR DESCRIPTION
Related issue: https://github.com/Adphorus/react-date-range/issues/61

Setting locale using `moment.locale('zh-cn');` outside of DateRange component, doesn't affect strings in Calendar when you're using webpack/babel.

I've added a new `locale` property which fixes the issue.