### PR TITLE
Add a prop to call onChange only when the step is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ class MyComponent extends Component {
 * **ranges:** *(Object)* default: none
 * **minDate:** *(String, Moment.js object, Function)* default: none
 * **maxDate:** *(String, Moment.js object, Function)* default: none
+* **twoStepChange:** *(Boolean)* default: false

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -88,21 +88,21 @@ var DateRange = (function (_Component) {
     }
   }, {
     key: 'setRange',
-    value: function setRange(range, source) {
+    value: function setRange(range, source, triggerChange) {
       var onChange = this.props.onChange;
 
       range = this.orderRange(range);
 
       this.setState({ range: range });
 
-      onChange && onChange(range, source, this.step);
+      if (triggerChange && onChange) onChange(range, source);
     }
   }, {
     key: 'handleSelect',
     value: function handleSelect(date, source) {
       if (date.startDate && date.endDate) {
         this.step = 0;
-        return this.setRange(date, source);
+        return this.setRange(date, source, true);
       }
 
       var _state$range = this.state.range;
@@ -127,7 +127,9 @@ var DateRange = (function (_Component) {
           break;
       }
 
-      this.setRange(range, source);
+      var triggerChange = this.step === 0 && this.props.twoStepChange;
+
+      this.setRange(range, source, triggerChange);
     }
   }, {
     key: 'handleLinkChange',
@@ -235,7 +237,8 @@ DateRange.defaultProps = {
   calendars: 2,
   onlyClasses: false,
   offsetPositive: false,
-  classNames: {}
+  classNames: {},
+  twoStepChange: false
 };
 
 DateRange.propTypes = {
@@ -249,6 +252,7 @@ DateRange.propTypes = {
   dateLimit: _react.PropTypes.func,
   ranges: _react.PropTypes.object,
   linkedCalendars: _react.PropTypes.bool,
+  twoStepChange: _react.PropTypes.bool,
   theme: _react.PropTypes.object,
   onInit: _react.PropTypes.func,
   onChange: _react.PropTypes.func,

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -95,7 +95,7 @@ var DateRange = (function (_Component) {
 
       this.setState({ range: range });
 
-      onChange && onChange(range, source);
+      onChange && onChange(range, source, this.step);
     }
   }, {
     key: 'handleSelect',

--- a/lib/DateRange.js
+++ b/lib/DateRange.js
@@ -127,7 +127,7 @@ var DateRange = (function (_Component) {
           break;
       }
 
-      var triggerChange = this.step === 0 && this.props.twoStepChange;
+      var triggerChange = !this.props.twoStepChange || this.step === 0 && this.props.twoStepChange;
 
       this.setRange(range, source, triggerChange);
     }

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -41,19 +41,19 @@ class DateRange extends Component {
     }
   }
 
-  setRange(range, source) {
+  setRange(range, source, triggerChange) {
     const { onChange } = this.props
     range = this.orderRange(range);
 
     this.setState({ range });
 
-    onChange && onChange(range, source, this.step);
+    if(triggerChange && onChange) onChange(range, source);
   }
 
   handleSelect(date, source) {
     if (date.startDate && date.endDate) {
       this.step = 0;
-      return this.setRange(date, source);
+      return this.setRange(date, source, true);
     }
 
     const { startDate, endDate } = this.state.range;
@@ -76,7 +76,9 @@ class DateRange extends Component {
         break;
     }
 
-    this.setRange(range, source);
+    const triggerChange = this.step === 0 && this.props.twoStepChange;
+
+    this.setRange(range, source, triggerChange);
   }
 
   handleLinkChange(direction) {
@@ -164,7 +166,8 @@ DateRange.defaultProps = {
   calendars       : 2,
   onlyClasses     : false,
   offsetPositive  : false,
-  classNames      : {}
+  classNames      : {},
+  twoStepChange   : false,
 }
 
 DateRange.propTypes = {
@@ -178,6 +181,7 @@ DateRange.propTypes = {
   dateLimit       : PropTypes.func,
   ranges          : PropTypes.object,
   linkedCalendars : PropTypes.bool,
+  twoStepChange   : PropTypes.bool,
   theme           : PropTypes.object,
   onInit          : PropTypes.func,
   onChange        : PropTypes.func,

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -76,7 +76,7 @@ class DateRange extends Component {
         break;
     }
 
-    const triggerChange = this.step === 0 && this.props.twoStepChange;
+    const triggerChange = !this.props.twoStepChange || this.step === 0 && this.props.twoStepChange;
 
     this.setRange(range, source, triggerChange);
   }

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -47,7 +47,7 @@ class DateRange extends Component {
 
     this.setState({ range });
 
-    onChange && onChange(range, source);
+    onChange && onChange(range, source, this.step);
   }
 
   handleSelect(date, source) {


### PR DESCRIPTION
This PR adds a prop to the date range component which allows it to call the `onChange` event only when both start and end dates have been explicitly set.