### PR TITLE
weekdaysMin now can use only one character

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -149,7 +149,7 @@ class Calendar extends Component {
       let day = moment.weekdaysMin(i);
       day = lang ? LangDic[lang][day.toLowerCase()] : day;
       weekdays.push(
-        <span style={onlyClasses ? undefined : styles['Weekday']} className={classes.weekDay} key={day}>{day}</span>
+        <span style={onlyClasses ? undefined : styles['Weekday']} className={classes.weekDay} key={i + day}>{day}</span>
       );
     }
 


### PR DESCRIPTION
*Story*

I have a design like this

![image](https://cloud.githubusercontent.com/assets/6443154/18469672/3f8a06c8-79d3-11e6-8c25-d40387b42238.png)

When use moment update locale. Everything working well. But the weekdaysMin you use as the React key, so i got the duplicate key problem S (Sunday) - S (Saturday), T (Tuesday) - T (Thursday).

```
moment.updateLocale('en', {
      months: [
        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
        'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
      ],
      weekdaysMin: ['S', 'M', 'T', 'W', 'T', 'F', 'S']
    });
```

Could you replace the key with loop index. I think it's better.

Line 130 - 131 of Calendar.js

```
    for (let i = dow; i < 7 + dow; i++) {
      const day = moment.weekdaysMin(i);

      weekdays.push(
        <span style={onlyClasses ? undefined : styles['Weekday']} className={classes.weekDay} key={day}>{day}</span>
      );
    }
```

Thanks and best regards!
