### PR TITLE
Fix bug in Calendar's "isToday" check

### DIFF
--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -289,7 +289,7 @@ var Calendar = (function (_Component) {
         days.push({ dayMoment: dayMoment, isPassive: true });
       }
 
-      var today = (0, _moment2['default'])().endOf('day');
+      var today = (0, _moment2['default'])().startOf('day');
       return days.map(function (data, index) {
         var dayMoment = data.dayMoment;
         var isPassive = data.isPassive;

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -205,7 +205,7 @@ class Calendar extends Component {
       days.push({ dayMoment, isPassive : true });
     }
 
-    const today = moment().endOf('day');
+    const today = moment().startOf('day');
     return days.map((data, index) => {
       const { dayMoment, isPassive } = data;
       const isSelected    = !range && (dayMoment.unix() === dateUnix);


### PR DESCRIPTION
Calendar component does not correctly mark today's date as today, because it compares the end of today to the start of the day being displayed.