### PR TITLE
Move react to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-range",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A React component for choosing dates and date ranges.",
   "main": "lib/index.js",
   "scripts": {
@@ -27,8 +27,10 @@
   },
   "dependencies": {
     "classnames": "^2.2.1",
-    "moment": "^2.10.6",
-    "react": "^0.14.8"
+    "moment": "^2.10.6"
+  },
+  "peerDependencies": {
+    "react": "^0.14 || ^15.0.0-rc || ^15.0"
   },
   "devDependencies": {
     "babel": "^5.8.23"


### PR DESCRIPTION
This prevents react-date-range from pulling in it's own React dependency, which causes problems for any project that doesn't share the same version.

fixes #90 