### PR TITLE
Add type attribute to calendar buttons

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -115,6 +115,7 @@ class Calendar extends Component {
         {
           showMonthArrow ?
           <button
+            type="button"
             style={onlyClasses ? undefined : { ...styles['MonthButton'], float : 'left' }}
             className={classes.prevButton}
             onClick={this.changeMonth.bind(this, -1)}>
@@ -129,6 +130,7 @@ class Calendar extends Component {
         {
           showMonthArrow ?
           <button
+            type="button"
             style={onlyClasses ? undefined : { ...styles['MonthButton'], float : 'right' }}
             className={classes.nextButton}
             onClick={this.changeMonth.bind(this, +1)}>


### PR DESCRIPTION
Hello,

Since `button` element inside `Calendar` component don't have `type` attribute, they prevent form to be submitted when user presses enter key.

---

Here's an example gif:

![kapture 2017-01-19 at 17 32 50](https://cloud.githubusercontent.com/assets/9790196/22110752/8685d68c-de65-11e6-8cff-e36a10ee1eb1.gif)

---

To fix this behaviour, I've just added `type="button"` attribute to them.
