### PR TITLE
Make the initial `date` property optional

### DIFF
--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -80,10 +80,10 @@ var Calendar = (function (_Component) {
       _moment2['default'].locale(locale);
     }
 
-    var date = (0, _utilsParseInputJs2['default'])(props.date, format, 'startOf');
+    var date = props.date && (0, _utilsParseInputJs2['default'])(props.date, format, 'startOf');
     var state = {
       date: date,
-      shownDate: (shownDate || range && range['endDate'] || date).clone().add(offset, 'months'),
+      shownDate: (shownDate || range && range['endDate'] || date || (0, _moment2['default'])().startOf('day')).clone().add(offset, 'months'),
       firstDayOfWeek: firstDayOfWeek || _moment2['default'].localeData().firstDayOfWeek()
     };
 
@@ -127,7 +127,6 @@ var Calendar = (function (_Component) {
       var _props2 = this.props;
       var link = _props2.link;
       var onChange = _props2.onChange;
-      var date = this.state.date;
 
       onChange && onChange(newDate, Calendar);
 
@@ -255,7 +254,7 @@ var Calendar = (function (_Component) {
       var date = _state.date;
       var firstDayOfWeek = _state.firstDayOfWeek;
 
-      var dateUnix = date.unix();
+      var dateUnix = date && date.unix();
 
       var monthNumber = shownDate.month();
       var dayCount = shownDate.daysInMonth();

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -42,10 +42,10 @@ class Calendar extends Component {
       moment.locale(locale);
     }
 
-    const date = parseInput(props.date, format, 'startOf')
+    const date = props.date && parseInput(props.date, format, 'startOf');
     const state = {
       date,
-      shownDate : (shownDate || range && range['endDate'] || date).clone().add(offset, 'months'),
+      shownDate : (shownDate || range && range['endDate'] || date || moment().startOf('day')).clone().add(offset, 'months'),
       firstDayOfWeek: (firstDayOfWeek || moment.localeData().firstDayOfWeek()),
     }
 
@@ -77,7 +77,6 @@ class Calendar extends Component {
 
   handleSelect(newDate) {
     const { link, onChange } = this.props;
-    const { date } = this.state;
 
     onChange && onChange(newDate, Calendar);
 
@@ -169,7 +168,7 @@ class Calendar extends Component {
 
     const shownDate                = this.getShownDate();
     const { date, firstDayOfWeek } = this.state;
-    const dateUnix                 = date.unix();
+    const dateUnix                 = date && date.unix();
 
     const monthNumber              = shownDate.month();
     const dayCount                 = shownDate.daysInMonth();


### PR DESCRIPTION
Instead of using today's date to pre-select a date it is only used to
determine which month to view by default.

Fixes #52