### PR TITLE
Don't unnecessarily bind arrow function

### DIFF
--- a/lib/PredefinedRanges.js
+++ b/lib/PredefinedRanges.js
@@ -70,7 +70,7 @@ var PredefinedRanges = (function (_Component) {
       var onlyClasses = _props.onlyClasses;
       var styles = this.styles;
 
-      return Object.keys(ranges).map((function (name) {
+      return Object.keys(ranges).map(function (name) {
         var _classnames;
 
         var active = (0, _utilsParseInputJs2['default'])(ranges[name].startDate, null, 'startOf').isSame(range.startDate) && (0, _utilsParseInputJs2['default'])(ranges[name].endDate, null, 'endOf').isSame(range.endDate);
@@ -90,7 +90,7 @@ var PredefinedRanges = (function (_Component) {
           },
           name
         );
-      }).bind(this));
+      });
     }
   }, {
     key: 'render',

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -54,7 +54,7 @@ class PredefinedRanges extends Component {
           {name}
         </a>
       );
-    }.bind(this));
+    });
   }
 
   render() {


### PR DESCRIPTION
Arrow functions are already bound to the parent context (or with babel in fact transpiled with an extra `_this` variable).

This threw a syntax error in some versions of Babel.