### PR TITLE
Added the ability to override the range name in predefined ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ class MyComponent extends Component {
 * **linkedCalendars:** *(Boolean)* default: false
 * **calendars:** *(Number)* default: 2
 * **ranges:** *(Object)* default: none
+	* in the format:
+	```
+	{
+		"Name of range": { // The object key will be displayed unless name is set.
+			name: (String), // optional string for name to display
+			startDate: (Moment.js object | String | Function),
+			endDate: (Moment.js object | String | Function)
+		},
+		"Another Range": { ... }
+	}
+	```
 * **minDate:** *(String, Moment.js object, Function)* default: none
 * **maxDate:** *(String, Moment.js object, Function)* default: none
 * **twoStepChange:** *(Boolean)* default: false

--- a/README.md
+++ b/README.md
@@ -88,19 +88,28 @@ class MyComponent extends Component {
 * **onChange:** *(Function)* default: none
 * **linkedCalendars:** *(Boolean)* default: false
 * **calendars:** *(Number)* default: 2
-* **ranges:** *(Object)* default: none
-	* in the format:
+* **ranges:** *(Object, Array)* default: none
+	* Creates buttons within the component that select preset date ranges.
+	* Use one of the following formats...
 	```
 	{
-		"Name of range": { // The object key will be displayed unless name is set.
-			name: (String), // optional string for name to display
-			lang: ({ en: String, fr: String, ...}), // optional translations for label. The one matching the `lang` prop of the DateRange
-																					  // will be used. If none is found, the `name` property will be used. If name is not
-																						// found, the object key will be used.
-			startDate: (Moment.js object | String | Function),
-			endDate: (Moment.js object | String | Function)
-		},
-		"Another Range": { ... }
+		"Name of range": Range,
+		"Another Range": Range
+	}
+	or
+	[Range, Range, Range]
+	```
+	* Each range object should use this format:
+	```
+	{
+		startDate: (Moment.js object | String | Function),
+		endDate: (Moment.js object | String | Function),
+		name: (String), // optional string for name to display.
+		lang: ({ en: String, fr: String, ...}) // optional translations for label.  
+			// The one matching the `lang` prop of the DateRange
+			// will be used. If none is found, the `name` property will be used. If name is not
+			// found, the object key will be used. If you use an array for ranges, either `name`
+			// or `lang` must be set.
 	}
 	```
 * **minDate:** *(String, Moment.js object, Function)* default: none

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ class MyComponent extends Component {
 	{
 		"Name of range": { // The object key will be displayed unless name is set.
 			name: (String), // optional string for name to display
+			lang: ({ en: String, fr: String, ...}), // optional translations for label. The one matching the `lang` prop of the DateRange
+																					  // will be used. If none is found, the `name` property will be used. If name is not
+																						// found, the object key will be used.
 			startDate: (Moment.js object | String | Function),
 			endDate: (Moment.js object | String | Function)
 		},

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -125,6 +125,7 @@ class DateRange extends Component {
             ranges={ ranges }
             range={ range }
             theme={ styles }
+            lang={ lang }
             onSelect={this.handleSelect.bind(this)}
             onlyClasses={ onlyClasses }
             classNames={ classes } />

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -190,7 +190,7 @@ DateRange.propTypes = {
   minDate         : PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.string]),
   maxDate         : PropTypes.oneOfType([PropTypes.object, PropTypes.func, PropTypes.string]),
   dateLimit       : PropTypes.func,
-  ranges          : PropTypes.object,
+  ranges          : PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   linkedCalendars : PropTypes.bool,
   twoStepChange   : PropTypes.bool,
   theme           : PropTypes.object,

--- a/src/LangDic.js
+++ b/src/LangDic.js
@@ -124,7 +124,7 @@ export default {
     'th':'목',
     'fr':'금',
     'sa':'토'
-  }
+  },
   'es' : { // Spanish
     'january':'Enero',
     'february':'Febrero',

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -25,14 +25,15 @@ class PredefinedRanges extends Component {
   }
 
   renderRangeList(classes) {
-    const { ranges, range, onlyClasses} = this.props;
+    const { ranges, range, onlyClasses, lang = ""} = this.props;
     const { styles } = this;
-    let displayName = "";
 
     return Object.keys(ranges).map(key => {
+      const currentRange = ranges[key];
+
       const active = (
-        parseInput(ranges[key].startDate, null, 'startOf').isSame(range.startDate) &&
-        parseInput(ranges[key].endDate, null, 'endOf').isSame(range.endDate)
+        parseInput(currentRange.startDate, null, 'startOf').isSame(range.startDate) &&
+        parseInput(currentRange.endDate, null, 'endOf').isSame(range.endDate)
       );
 
       const style = {
@@ -46,9 +47,19 @@ class PredefinedRanges extends Component {
       });
 
       // check for a name property to decide how to name the ranges.
-      displayName = key;
-      if (ranges[key].name !== undefined) {
-        displayName = ranges[key].name;
+      let displayName = "";
+      if (currentRange.name !== undefined) {
+        displayName = currentRange.name;
+      }
+      // if the currentRange has a lang property, check it for the current language.
+      if (lang && currentRange.lang !== undefined) {
+        if (currentRange.lang[lang]) {
+          displayName = currentRange.lang[lang];
+        }
+      }
+      // if nothing was set so far, use the key in the object.
+      if (displayName === "") {
+        displayName = key;
       }
 
       return (
@@ -90,7 +101,8 @@ PredefinedRanges.defaultProps = {
 PredefinedRanges.propTypes = {
   ranges      : PropTypes.object.isRequired,
   onlyClasses : PropTypes.bool,
-  classNames  : PropTypes.object
+  classNames  : PropTypes.object,
+  lang: PropTypes.string
 }
 
 export default PredefinedRanges;

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -25,13 +25,14 @@ class PredefinedRanges extends Component {
   }
 
   renderRangeList(classes) {
-    const { ranges, range, onlyClasses } = this.props;
+    const { ranges, range, onlyClasses} = this.props;
     const { styles } = this;
+    let displayName = "";
 
-    return Object.keys(ranges).map(name => {
+    return Object.keys(ranges).map(key => {
       const active = (
-        parseInput(ranges[name].startDate, null, 'startOf').isSame(range.startDate) &&
-        parseInput(ranges[name].endDate, null, 'endOf').isSame(range.endDate)
+        parseInput(ranges[key].startDate, null, 'startOf').isSame(range.startDate) &&
+        parseInput(ranges[key].endDate, null, 'endOf').isSame(range.endDate)
       );
 
       const style = {
@@ -44,15 +45,21 @@ class PredefinedRanges extends Component {
         [classes.predefinedRangesItemActive]: active
       });
 
+      // check for a name property to decide how to name the ranges.
+      displayName = key;
+      if (ranges[key].name !== undefined) {
+        displayName = ranges[key].name;
+      }
+
       return (
         <a
           href='#'
-          key={'range-' + name}
+          key={'range-' + key}
           className={predefinedRangeClass}
           style={ onlyClasses ? undefined : style }
-          onClick={this.handleSelect.bind(this, name)}
+          onClick={this.handleSelect.bind(this, key)}
         >
-          {name}
+          {displayName}
         </a>
       );
     }.bind(this));

--- a/src/PredefinedRanges.js
+++ b/src/PredefinedRanges.js
@@ -25,11 +25,18 @@ class PredefinedRanges extends Component {
   }
 
   renderRangeList(classes) {
+    let rangeArray;
     const { ranges, range, onlyClasses, lang = ""} = this.props;
     const { styles } = this;
 
-    return Object.keys(ranges).map(key => {
-      const currentRange = ranges[key];
+    if (Array.isArray(ranges)) {
+      rangeArray = ranges;
+    } else {
+      // convert object into array where key is stored as a name property of each range.
+      rangeArray = Object.keys(ranges).map(key => Object.assign({name: key}, ranges[key]))
+    }
+
+    return rangeArray.map(currentRange => {
 
       const active = (
         parseInput(currentRange.startDate, null, 'startOf').isSame(range.startDate) &&
@@ -59,16 +66,16 @@ class PredefinedRanges extends Component {
       }
       // if nothing was set so far, use the key in the object.
       if (displayName === "") {
-        displayName = key;
+        console.warn("You forgot to assign a `name` or valid `lang` property to one of your ranges.");
       }
 
       return (
         <a
           href='#'
-          key={'range-' + key}
+          key={'range-' + displayName}
           className={predefinedRangeClass}
           style={ onlyClasses ? undefined : style }
-          onClick={this.handleSelect.bind(this, key)}
+          onClick={this.handleSelect.bind(this, displayName)}
         >
           {displayName}
         </a>
@@ -99,7 +106,7 @@ PredefinedRanges.defaultProps = {
 };
 
 PredefinedRanges.propTypes = {
-  ranges      : PropTypes.object.isRequired,
+  ranges      : PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   onlyClasses : PropTypes.bool,
   classNames  : PropTypes.object,
   lang: PropTypes.string


### PR DESCRIPTION
You can now provide a "name" property to a date range in "ranges" so that you can override the name that appears in the sidebar when you provide preset ranges. I'm hoping this makes it slightly easier to work with especially when using multiple languages.