### PR TITLE
Updated LangDic.js

### DIFF
--- a/src/LangDic.js
+++ b/src/LangDic.js
@@ -77,7 +77,7 @@ export default {
     'december':'dicembre',
     'su':'Domenica',
     'mo':'Lunedì',
-    'tu':'Mardi',
+    'tu':'Martedì',
     'we':'Mercoledì',
     'th':'Giovedì',
     'fr':'Venerdì',


### PR DESCRIPTION
The correct italian translation for 'tuesday' is 'Martedì', not 'Mardi'