### PR TITLE
Fix for cellSize calculation causing wrapping of day-cells in Firefox

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -186,7 +186,7 @@ export default (customTheme = {}) => {
       cellMargin = customTheme.Day.margin;
   }
 
-  const cellSize = (( parseInt(calendarWidth) - parseInt(calendarPadding) * 2 ) / 7 ) - ( parseInt(cellMargin) * 2 );
+  const cellSize = Math.floor((( parseInt(calendarWidth) - parseInt(calendarPadding) * 2 ) / 7 ) - ( parseInt(cellMargin) * 2 ));
 
   return {
     DateRange : { ...defaultTheme.DateRange, ...customTheme.DateRange },


### PR DESCRIPTION
This PR fixes a bug in Firefox where the browsers round the width calculation up to 37.1429px, which causes the cells to wrap past the bounds of the container (because 37.1429 x 7 (days of the week) = 260.0003, which, when you add the 10px padding either side equals 280.0003px, which is greater than the 280px container = 💥).

Example of the problem in Firefox (note Saturday wrapping):
<img width="1024" alt="screen shot 2017-12-06 at 11 34 17 am" src="https://user-images.githubusercontent.com/819605/33691451-015abfa0-db34-11e7-8a59-a8f3caafd43e.png">
