### PR TITLE
Add missing comma in LangDic.js

### DIFF
--- a/src/LangDic.js
+++ b/src/LangDic.js
@@ -124,7 +124,7 @@ export default {
     'th':'목',
     'fr':'금',
     'sa':'토'
-  }
+  },
   'es' : { // Spanish
     'january':'Enero',
     'february':'Febrero',


### PR DESCRIPTION
Append missing comma in `LangDic.js` file between Korean and Spanish.