### PR TITLE
Pass dateOptions to the month name format call

### DIFF
--- a/src/components/Month.js
+++ b/src/components/Month.js
@@ -57,7 +57,7 @@ class Month extends PureComponent {
       <div className={styles.month} style={this.props.style}>
         {this.props.showMonthName ? (
           <div className={styles.monthName}>
-            {format(this.props.month, this.props.monthDisplayFormat)}
+            {format(this.props.month, this.props.monthDisplayFormat, this.props.dateOptions)}
           </div>
         ) : null}
         {this.props.showWeekDays && renderWeekdays(styles, this.props.dateOptions)}


### PR DESCRIPTION
Hello,

I noticed the month name wasn't localized when displayed.
After further inspection, I noticed the dateOptions weren't passed through to this format call, so here's a quickfix to solve this.

Have a good day !