### PR TITLE
Firefox month/year selection bug

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -166,7 +166,7 @@ class Calendar extends PureComponent {
     const lowerYearLimit = minDate.getFullYear();
     const styles = this.styles;
     return (
-      <div className={styles.monthAndYearWrapper}>
+      <div onMouseUp={e => e.stopPropagation()} className={styles.monthAndYearWrapper}>
         {showMonthArrow ? (
           <button
             type="button"


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
On firefox browsers, year picker is not working because the `onMouseUp` event that exists on calendar container, de-attached the target value of year picker. So I stopped the propagation on Year and Month pickers containers.

> Related Issue: #201 