### PR TITLE
Enable disabling of certain dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Momentjs: `moment(dateString).toDate()`
 - `specialDays` prop removed.
 
 ### Added
+- `disabledDates` prop: It's a set of disabled dates.
 - `DefinedRanges` component: It's a set of date presets. Receives `inputRanges`, `staticRanges` for setting date ranges.
 - `DateRangePicker` component. It's combined version of `DateRange` with `DefinedRanges` component.
 - Date range selection by drag.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ shownDate                            | Date      |                  | initial fo
 minDate                              | Date      |                  | defines minimum date. Disabled earlier dates
 maxDate                              | Date      |                  | defines maximum date. Disabled later dates
 direction                            | String    | 'vertical'       | direction of calendar months. can be `vertical` or `horizontal`
+disabledDates                        | Date[]    | []               | dates that are disabled
 scroll                       				 | Object    | { enabled: false }| infinite scroll behaviour configuration. Check out [Infinite Scroll](#infinite-scrolled-mode) section
 showMonthArrow                       | Boolean   | true             | show/hide month arrow button
 navigatorRenderer                    | Func      |                  | renderer for focused date navigation area. fn(currentFocusedDate: Date, changeShownDate: func, props: object)

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -346,6 +346,7 @@ export default class Main extends Component {
             ranges={[this.state.dateRangeWithDisabled.selection]}
             className={'PreviewArea'}
             disabledDates={[Date()]}
+            minDate={new Date(new Date().getTime() - 3 * 24 * 60 * 60 * 1000)}
           />
         </Section>
       </main>

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -72,6 +72,13 @@ export default class Main extends Component {
           key: 'selection',
         },
       },
+      dateRangeWithDisabled: {
+        selection: {
+          startDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
+          endDate: null,
+          key: 'selection',
+        },
+      },
       definedRange: {
         selection: {
           startDate: new Date(),
@@ -314,6 +321,31 @@ export default class Main extends Component {
             ranges={[this.state.definedRange.selection]}
             onChange={this.handleRangeChange.bind(this, 'definedRange')}
             className={'centered'}
+          />
+        </Section>
+        <Section title="RangePicker with disabled dates">
+          <div>
+            <input
+              type="text"
+              readOnly
+              value={formatDateDisplay(this.state.dateRangeWithDisabled.selection.startDate)}
+            />
+            <input
+              type="text"
+              readOnly
+              value={formatDateDisplay(
+                this.state.dateRangeWithDisabled.selection.endDate,
+                'Continuous'
+              )}
+            />
+          </div>
+
+          <DateRange
+            onChange={this.handleRangeChange.bind(this, 'dateRangeWithDisabled')}
+            moveRangeOnFirstSelection={false}
+            ranges={[this.state.dateRangeWithDisabled.selection]}
+            className={'PreviewArea'}
+            disabledDates={[Date()]}
           />
         </Section>
       </main>

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -345,7 +345,7 @@ export default class Main extends Component {
             moveRangeOnFirstSelection={false}
             ranges={[this.state.dateRangeWithDisabled.selection]}
             className={'PreviewArea'}
-            disabledDates={[Date()]}
+            disabledDates={[new Date()]}
             minDate={new Date(new Date().getTime() - 3 * 24 * 60 * 60 * 1000)}
           />
         </Section>

--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -74,7 +74,7 @@ export default class Main extends Component {
       },
       dateRangeWithDisabled: {
         selection: {
-          startDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
+          startDate: addDays(new Date(), 4),
           endDate: null,
           key: 'selection',
         },
@@ -345,8 +345,8 @@ export default class Main extends Component {
             moveRangeOnFirstSelection={false}
             ranges={[this.state.dateRangeWithDisabled.selection]}
             className={'PreviewArea'}
-            disabledDates={[new Date()]}
-            minDate={new Date(new Date().getTime() - 3 * 24 * 60 * 60 * 1000)}
+            disabledDates={[new Date(), addDays(new Date(), 3)]}
+            minDate={addDays(new Date(), -3)}
           />
         </Section>
       </main>

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -116,7 +116,7 @@ class Calendar extends PureComponent {
       setTimeout(() => this.focusToDate(this.state.focusedDate), 1);
     }
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const propMapper = {
       dateRange: 'ranges',
       date: 'date',
@@ -351,6 +351,7 @@ class Calendar extends PureComponent {
       onPreviewChange,
       scroll,
       direction,
+      disabledDates,
       maxDate,
       minDate,
       rangeColors,
@@ -400,6 +401,8 @@ class Calendar extends PureComponent {
                 axis={isVertical ? 'y' : 'x'}
                 itemRenderer={(index, key) => {
                   const monthStep = addMonths(minDate, index);
+                  let tomorrow = new Date();
+                  tomorrow.setDate(tomorrow.getDate + 1);
                   return (
                     <Month
                       {...this.props}
@@ -409,6 +412,7 @@ class Calendar extends PureComponent {
                       key={key}
                       drag={this.state.drag}
                       dateOptions={this.dateOptions}
+                      disabledDates={disabledDates}
                       month={monthStep}
                       onDragSelectionStart={this.onDragSelectionStart}
                       onDragSelectionEnd={this.onDragSelectionEnd}
@@ -436,6 +440,8 @@ class Calendar extends PureComponent {
             )}>
             {new Array(this.props.months).fill(null).map((_, i) => {
               const monthStep = addMonths(this.state.focusedDate, i);
+              let tomorrow = new Date();
+              tomorrow.setDate(tomorrow.getDate + 1);
               return (
                 <Month
                   {...this.props}
@@ -445,6 +451,7 @@ class Calendar extends PureComponent {
                   key={i}
                   drag={this.state.drag}
                   dateOptions={this.dateOptions}
+                  disabledDates={disabledDates}
                   month={monthStep}
                   onDragSelectionStart={this.onDragSelectionStart}
                   onDragSelectionEnd={this.onDragSelectionEnd}
@@ -466,6 +473,7 @@ class Calendar extends PureComponent {
 Calendar.defaultProps = {
   showMonthArrow: true,
   showMonthAndYearPickers: true,
+  disabledDates: [],
   classNames: {},
   locale: defaultLocale,
   ranges: [],
@@ -490,6 +498,7 @@ Calendar.defaultProps = {
 Calendar.propTypes = {
   showMonthArrow: PropTypes.bool,
   showMonthAndYearPickers: PropTypes.bool,
+  disabledDates: PropTypes.array,
   minDate: PropTypes.object,
   maxDate: PropTypes.object,
   date: PropTypes.object,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -401,8 +401,6 @@ class Calendar extends PureComponent {
                 axis={isVertical ? 'y' : 'x'}
                 itemRenderer={(index, key) => {
                   const monthStep = addMonths(minDate, index);
-                  let tomorrow = new Date();
-                  tomorrow.setDate(tomorrow.getDate + 1);
                   return (
                     <Month
                       {...this.props}
@@ -440,8 +438,6 @@ class Calendar extends PureComponent {
             )}>
             {new Array(this.props.months).fill(null).map((_, i) => {
               const monthStep = addMonths(this.state.focusedDate, i);
-              let tomorrow = new Date();
-              tomorrow.setDate(tomorrow.getDate + 1);
               return (
                 <Month
                   {...this.props}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -116,7 +116,7 @@ class Calendar extends PureComponent {
       setTimeout(() => this.focusToDate(this.state.focusedDate), 1);
     }
   }
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps) {
     const propMapper = {
       dateRange: 'ranges',
       date: 'date',

--- a/src/components/DateRange.js
+++ b/src/components/DateRange.js
@@ -3,15 +3,7 @@ import PropTypes from 'prop-types';
 import Calendar from './Calendar.js';
 import { rangeShape } from './DayCell';
 import { findNextRangeIndex, generateStyles } from '../utils.js';
-import {
-  isBefore,
-  differenceInCalendarDays,
-  addDays,
-  min,
-  isWithinInterval,
-  isAfter,
-  max,
-} from 'date-fns';
+import { isBefore, differenceInCalendarDays, addDays, min, isWithinInterval, max } from 'date-fns';
 import classnames from 'classnames';
 import coreStyles from '../styles';
 
@@ -68,9 +60,9 @@ class DateRange extends Component {
 
     if (inValidDatesWithinRange.length > 0) {
       if (isStartDateSelected) {
-        startDate = addDays(max(disabledDates.filter(date => isBefore(date, endDate))), 1);
+        startDate = addDays(max(inValidDatesWithinRange), 1);
       } else {
-        endDate = addDays(min(disabledDates.filter(date => isAfter(date, startDate))), -1);
+        endDate = addDays(min(inValidDatesWithinRange), -1);
       }
     }
 

--- a/src/components/DateRange.js
+++ b/src/components/DateRange.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Calendar from './Calendar.js';
 import { rangeShape } from './DayCell';
 import { findNextRangeIndex, generateStyles } from '../utils.js';
-import { isBefore, differenceInCalendarDays, addDays, min } from 'date-fns';
+import { isBefore, differenceInCalendarDays, addDays, min, isWithinInterval } from 'date-fns';
 import classnames from 'classnames';
 import coreStyles from '../styles';
 
@@ -58,12 +58,22 @@ class DateRange extends Component {
     };
   }
   setSelection(value, isSingleValue) {
-    const { onChange, ranges, onRangeFocusChange } = this.props;
+    const { onChange, ranges, onRangeFocusChange, disabledDates } = this.props;
     const focusedRange = this.props.focusedRange || this.state.focusedRange;
     const focusedRangeIndex = focusedRange[0];
     const selectedRange = ranges[focusedRangeIndex];
     if (!selectedRange) return;
     const newSelection = this.calcNewSelection(value, isSingleValue);
+    if (
+      disabledDates.some(disabledDate =>
+        isWithinInterval(disabledDate, {
+          start: newSelection.range.startDate,
+          end: newSelection.range.endDate,
+        })
+      )
+    ) {
+      return;
+    }
     onChange({
       [selectedRange.key || `range${focusedRangeIndex + 1}`]: {
         ...selectedRange,

--- a/src/components/DateRange.js
+++ b/src/components/DateRange.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 import Calendar from './Calendar.js';
 import { rangeShape } from './DayCell';
 import { findNextRangeIndex, generateStyles } from '../utils.js';
-import { isBefore, differenceInCalendarDays, addDays, min, isWithinInterval } from 'date-fns';
+import {
+  isBefore,
+  differenceInCalendarDays,
+  addDays,
+  min,
+  isWithinInterval,
+  isAfter,
+  max,
+} from 'date-fns';
 import classnames from 'classnames';
 import coreStyles from '../styles';
 
@@ -45,9 +53,9 @@ class DateRange extends Component {
     }
 
     // reverse dates if startDate before endDate
-    let hasBeenReversed = false;
+    let isStartDateSelected = focusedRange[1] === 0;
     if (isBefore(endDate, startDate)) {
-      hasBeenReversed = true;
+      isStartDateSelected = !isStartDateSelected;
       [startDate, endDate] = [endDate, startDate];
     }
 
@@ -59,12 +67,10 @@ class DateRange extends Component {
     );
 
     if (inValidDatesWithinRange.length > 0) {
-      if (hasBeenReversed) {
-        const minDate = new Date(Math.min.apply(null, inValidDatesWithinRange));
-        startDate = new Date(minDate.getTime() + 24 * 60 * 60 * 1000);
+      if (isStartDateSelected) {
+        startDate = addDays(max(disabledDates.filter(date => isBefore(date, endDate))), 1);
       } else {
-        const maxDate = new Date(Math.max.apply(null, inValidDatesWithinRange));
-        endDate = new Date(maxDate.getTime() - 24 * 60 * 60 * 1000);
+        endDate = addDays(min(disabledDates.filter(date => isAfter(date, startDate))), -1);
       }
     }
 
@@ -102,7 +108,7 @@ class DateRange extends Component {
     this.props.onRangeFocusChange && this.props.onRangeFocusChange(focusedRange);
   }
   updatePreview(val) {
-    if (!val || !val.wasValid) {
+    if (!val) {
       this.setState({ preview: null });
       return;
     }

--- a/src/components/Month.js
+++ b/src/components/Month.js
@@ -36,7 +36,7 @@ function renderWeekdays(styles, dateOptions) {
 class Month extends PureComponent {
   render() {
     const now = new Date();
-    const { displayMode, focusedRange, drag, styles } = this.props;
+    const { displayMode, focusedRange, drag, styles, disabledDates } = this.props;
     const minDate = this.props.minDate && startOfDay(this.props.minDate);
     const maxDate = this.props.maxDate && endOfDay(this.props.maxDate);
     const monthDisplay = getMonthDisplayRange(this.props.month, this.props.dateOptions);
@@ -68,6 +68,9 @@ class Month extends PureComponent {
               const isEndOfMonth = isSameDay(day, monthDisplay.endDateOfMonth);
               const isOutsideMinMax =
                 (minDate && isBefore(day, minDate)) || (maxDate && isAfter(day, maxDate));
+              const isDisabledSpecifically = disabledDates.some(disabledDate =>
+                isSameDay(disabledDate, day)
+              );
               return (
                 <DayCell
                   {...this.props}
@@ -81,7 +84,7 @@ class Month extends PureComponent {
                   isStartOfMonth={isStartOfMonth}
                   isEndOfMonth={isEndOfMonth}
                   key={index}
-                  disabled={isOutsideMinMax}
+                  disabled={isOutsideMinMax || isDisabledSpecifically}
                   isPassive={
                     !isWithinInterval(day, {
                       start: monthDisplay.startDateOfMonth,
@@ -112,6 +115,7 @@ Month.propTypes = {
   month: PropTypes.object,
   drag: PropTypes.object,
   dateOptions: PropTypes.object,
+  disabledDates: PropTypes.array,
   preview: PropTypes.shape({
     startDate: PropTypes.object,
     endDate: PropTypes.object,


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

- Added a `disabledDates` props which holds an array of dates to be disabled. These days will be rendered with the disabled props.
- Also handles the case when you would select a range that includes one of the disabled dates.
- Added an example using this feature to the demo

> Related Issue: #213