### PR TITLE
Add react 16 as possible peer dep

### DIFF
--- a/demo/src/components/Main.js
+++ b/demo/src/components/Main.js
@@ -110,7 +110,7 @@ export default class Main extends Component {
           autoFocus: false,
         },
       },
-      datePickerInternational: null,
+      datePickerInternational: new Date(),
       locale: 'ja',
       dateRangePicker: {
         selection: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-list": "^0.8.8"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0.0-rc || >=15.0"
+    "react": "^0.14 || ^15.0.0-rc || >=15.0 || ^16.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.2.4",


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Update package json to for react 16. It worked in my project, and didn't induce any errors in the demo or tests. The only warning I found is `componentWillReceiveProps` using React 16.3 in strict mode, as seen in issue #187. Per 16.3 [release notes](https://medium.com/@baphemot/whats-new-in-react-16-3-d2c9b7b6193b), it's not slated for a deprecation notice until 16.4, and removal is not planned until 17. I also fixed a warning for an uncontrolled component in the demo.

> Related Issue: #166