### PR TITLE
#255 fix issue where in Edge week days row not displaying as 7

### DIFF
--- a/src/components/dayCell.scss
+++ b/src/components/dayCell.scss
@@ -6,6 +6,12 @@
   cursor: pointer;
 }
 
+@supports (-ms-ime-align: auto) {
+  .rdrDay {
+    flex-basis: 14.285% !important;
+  }
+}
+
 .rdrDayNumber {
   display: block;
   position: relative;


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)

## Description
Saturday is not shown on Edge, due to css calc bug in Edge.

> Related Issue: #255 