### PR TITLE
Fix issue with month and year picker in scroll mode

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -113,7 +113,7 @@ class Calendar extends PureComponent {
   componentDidMount() {
     if (this.props.scroll.enabled) {
       // prevent react-list's initial render focus problem
-      setTimeout(() => this.focusToDate(this.state.focusedDate), 1);
+      setTimeout(() => this.focusToDate(this.state.focusedDate), 1000);
     }
   }
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
When the `showDate`, `minDate` and `maxDate` are set, the `showDate` does not show as focused, hence the month and year at the to of the calendar displayed the minimum date.

This was due to the `focusedDate` being set later.
Adding more delay to the call to `focusToDate` solves this issue.

> Related Issue: https://github.com/Adphorus/react-date-range/issues/215