### PR TITLE
Update default static ranges

### DIFF
--- a/src/defaultRanges.js
+++ b/src/defaultRanges.js
@@ -45,44 +45,56 @@ export const defaultStaticRanges = createStaticRanges([
   {
     label: 'Today',
     range: () => ({
-      startDate: defineds.startOfToday,
-      endDate: defineds.endOfToday,
+      range: {
+        startDate: defineds.startOfToday,
+        endDate: defineds.endOfToday,
+      },
     }),
   },
   {
     label: 'Yesterday',
     range: () => ({
-      startDate: defineds.startOfYesterday,
-      endDate: defineds.endOfYesterday,
+      range: {
+        startDate: defineds.startOfYesterday,
+        endDate: defineds.endOfYesterday,
+      },
     }),
   },
 
   {
     label: 'This Week',
     range: () => ({
-      startDate: defineds.startOfWeek,
-      endDate: defineds.endOfWeek,
+      range: {
+        startDate: defineds.startOfWeek,
+        endDate: defineds.endOfWeek,
+      },
     }),
   },
   {
     label: 'Last Week',
     range: () => ({
-      startDate: defineds.startOfLastWeek,
-      endDate: defineds.endOfLastWeek,
+      range: {
+        startDate: defineds.startOfLastWeek,
+        endDate: defineds.endOfLastWeek,
+      },
     }),
   },
   {
     label: 'This Month',
     range: () => ({
-      startDate: defineds.startOfMonth,
-      endDate: defineds.endOfMonth,
+      range: {
+        startDate: defineds.startOfMonth,
+        endDate: defineds.endOfMonth,
+      },
     }),
   },
   {
     label: 'Last Month',
     range: () => ({
-      startDate: defineds.startOfLastMonth,
-      endDate: defineds.endOfLastMonth,
+      range: {
+        startDate: defineds.startOfLastMonth,
+        endDate: defineds.endOfLastMonth,
+      },
     }),
   },
 ]);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
`defaultStaticRanges` has incorrect structure and doesn't work. Adding a `range` property is not a best solution, but it doesn't break existing functionality. 