### PR TITLE
Added Day Number Color prop to ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ inputRanges(`DefinedRange`, `DateRangePicker`)   | Array            | [default i
     startDate: PropTypes.object,
     endDate: PropTypes.object,
     color: PropTypes.string,
+    dayNumberColor: PropTypes.string,
     key: PropTypes.string,
     autoFocus: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -74,6 +74,7 @@ const [state, setState] = useState({
   selection3: {
     startDate: addDays(new Date(), 8),
     endDate: addDays(new Date(), 10),
+    dayNumberColor: '#000000',
     key: 'selection3',
     autoFocus: false
   }

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -102,16 +102,13 @@ class DayCell extends Component {
       />
     );
   };
-  renderSelectionPlaceholders = () => {
-    const { styles, ranges, day } = this.props;
-    if (this.props.displayMode === 'date') {
-      let isSelected = isSameDay(this.props.day, this.props.date);
-      return isSelected ? (
-        <span className={styles.selected} style={{ color: this.props.color }} />
-      ) : null;
+  getInRanges = () => {
+    const { ranges, day } = this.props;
+    if (this.props.displayMode !== 'dateRange') {
+      return null;
     }
 
-    const inRanges = ranges.reduce((result, range) => {
+    return ranges.reduce((result, range) => {
       let startDate = range.startDate;
       let endDate = range.endDate;
       if (startDate && endDate && isBefore(endDate, startDate)) {
@@ -136,6 +133,16 @@ class DayCell extends Component {
       }
       return result;
     }, []);
+  };
+  renderSelectionPlaceholders = inRanges => {
+    const { styles } = this.props;
+    if (this.props.displayMode === 'date') {
+      let isSelected = isSameDay(this.props.day, this.props.date);
+      return isSelected ? (
+        <span className={styles.selected} style={{ color: this.props.color }} />
+      ) : null;
+    }
+    inRanges = inRanges === undefined ? this.getInRanges() : inRanges;
 
     return inRanges.map((range, i) => (
       <span
@@ -149,7 +156,18 @@ class DayCell extends Component {
       />
     ));
   };
+  getDayNumberColor = inRanges => {
+    if (inRanges === null) {
+      return;
+    }
+    inRanges = inRanges === undefined ? this.getInRanges() : inRanges;
+    if (inRanges.length === 0) {
+      return;
+    }
+    return inRanges[inRanges.length - 1].dayNumberColor;
+  };
   render() {
+    const ranges = this.getInRanges();
     return (
       <button
         type="button"
@@ -165,10 +183,12 @@ class DayCell extends Component {
         className={this.getClassNames(this.props.styles)}
         {...(this.props.disabled || this.props.isPassive ? { tabIndex: -1 } : {})}
         style={{ color: this.props.color }}>
-        {this.renderSelectionPlaceholders()}
+        {this.renderSelectionPlaceholders(ranges)}
         {this.renderPreviewPlaceholder()}
         <span className={this.props.styles.dayNumber}>
-          <span>{format(this.props.day, this.props.dayDisplayFormat)}</span>
+          <span style={{ color: this.getDayNumberColor(ranges) }}>
+            {format(this.props.day, this.props.dayDisplayFormat)}
+          </span>
         </span>
       </button>
     );
@@ -181,6 +201,7 @@ export const rangeShape = PropTypes.shape({
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   color: PropTypes.string,
+  dayNumberColor: PropTypes.string,
   key: PropTypes.string,
   autoFocus: PropTypes.bool,
   disabled: PropTypes.bool,


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Currently, it seems the only way to overwrite the color of the date number text in a range is to use CSS, and any change will be applied to all ranges. This can lead to an issue if someone wants to apply different text colors to different ranges. This can come up when one range's color is very bright, necessitating a dark text color, and one range is very dark, necessitating a bright text color. In addition, it is nice to be able to set the text color with a prop, rather than having to overwrite/modify the default CSS.

This PR adds dayNumberColor as a prop on the ranges object and applies that color to the day number text of any date shown in that range.

> Related Issue: #383 