### PR TITLE
Prevent upgrades to incompatible date-fns 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "shallow-equal": "^1.2.1"
   },
   "peerDependencies": {
-    "date-fns": "3.0.6 || >=3.0.0",
+    "date-fns": "^3.0.0",
     "react": "^0.14 || ^15.0.0-rc || >=15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
The library date-fns was just upgraded to [v4.0.0](https://github.com/date-fns/date-fns/releases/tag/v4.0.0). However, this library is not compatible with date-functions@4.0.0. Using a semver ^ will allow only compatible versions of date-fns to be used as a peer dependency.